### PR TITLE
Changing URL for sending PR

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -43,7 +43,7 @@ def get_page(command, platform=None):
                 raise
 
     print(command + " documentation is not available\n"
-          "Consider contributing Pull Request to https://github.com/rprieto/tldr")
+          "Consider contributing Pull Request to https://github.com/tldr-pages/tldr")
 
 def output(page):
     # Need a better fancy method?


### PR DESCRIPTION
With the move of the repos into another organization, the URL for the
base tldr project has changed. Updating the message to reflect this
change
