### PR TITLE
Read colors from os.environ

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -54,7 +54,7 @@ DEFAULT_COLORS = {
 }
 
 def colors_of(key):
-    env_key = 'TLDR_%s' % key.upper()
+    env_key = 'TLDR_COLOR_%s' % key.upper()
     values = os.environ.get(env_key, '').strip() or DEFAULT_COLORS[key]
     values = values.split()
     return (


### PR DESCRIPTION
Default colors are not readable on some themed terminals. example:
![snapshot](https://cloud.githubusercontent.com/assets/767425/3826398/64d09120-1d61-11e4-8ada-31714ae9b564.png)

Environment variables named `tldr_blank_line`, `tldr_command_name`, `tldr_short_desc`, `tldr_example`, `tldr_command_args`, `tldr_other` can override default colors if exist. example:

`$ tldr_example="red on_blue bold underline" python tldr.py tar`
