### PR TITLE
Issue 23: Added ability to omit background color option

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -109,8 +109,8 @@ def colors_of(key):
     values = values.split()
     return (
         values[0] if len(values) > 0 else None,
-        values[1] if len(values) > 1 else None,
-        values[2:],
+        values[1] if len(values) > 1 and values[1].startswith('on_') else None,
+        values[2:] if len(values) > 1 and values[1].startswith('on_') else values[1:],
     )
 
 


### PR DESCRIPTION
Now you can specify additional text effects without specifying text background color:

![bwh1te bwh1te-peka -projects-github-tldr-python-client_007](https://cloud.githubusercontent.com/assets/946520/12338134/f7d09ea8-bb2f-11e5-88fb-200cb919f9ef.png)

![bwh1te bwh1te-peka -projects-github-tldr-python-client_008](https://cloud.githubusercontent.com/assets/946520/12338139/ffc056ee-bb2f-11e5-8180-b586cfb439b2.png)

