### PR TITLE
Use recent cache instead of always downloading 

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A `Python` command line client for [tldr](https://github.com/tldr-pages/tldr).
 * `tldr <command>`
 
 ## Configuration
-You can configure output of `tldr` client through setting an environment variables. For example, in `.bashrc` file:
+You can configure the behaviour and output of the `tldr` client by setting environment variables. For example, in the `.bashrc` file:
 
     export TLDR_COLOR_BLANK="white"
     export TLDR_COLOR_NAME="cyan"
@@ -24,8 +24,18 @@ You can configure output of `tldr` client through setting an environment variabl
     export TLDR_COLOR_EXAMPLE="green"
     export TLDR_COLOR_COMMAND="red"
     export TLDR_COLOR_PARAMETER="white"
+    export TLDR_CACHE_ENABLED=1
+    export TLDR_CACHE_MAX_AGE=720
+
+### Cache
+* `TLDR_CACHE_ENABLED` (default is `1`):
+    * If set to `1`, the client will first try to load from cache, and fall back to fetching from the internet if the cache doesn't exist or is to old.
+    * If set to `0`, the client will fetch from the internet, and fall back to the cache if the page cannot be fetched from the internet.
+* `TLDR_CACHE_MAX_AGE` (default is `24`): maximum age of the cache in hours to be considered as valid when `TLDR_CACHE_ENABLED` is set to `1`.
+
+### Colors
     
-Values of these variables may consist of three parts: 
+Values of the `TLDR_COLOR_x` variables may consist of three parts: 
 * Font color, *required*: `blue, green, yellow, cyan, magenta, white, grey, red`
 * Background color: `on_blue, on_cyan, on_magenta, on_white, on_grey, on_yellow, on_red, on_green`
 * Additional effects, which depends on platform: `reverse, blink, dark, concealed, underline, bold`

--- a/tldr.py
+++ b/tldr.py
@@ -114,7 +114,6 @@ def have_recent_cache(command, platform):
         cache_file_path = get_cache_file_path(command, platform)
         last_modified = datetime.fromtimestamp(os.path.getmtime(cache_file_path))
         minutes_passed = (datetime.now() - last_modified).total_seconds() / 60
-        print(minutes_passed, MAX_CACHE_AGE, minutes_passed <= MAX_CACHE_AGE)
         return minutes_passed <= MAX_CACHE_AGE
     except Exception:
         return False

--- a/tldr.py
+++ b/tldr.py
@@ -17,8 +17,8 @@ from six.moves import map
 import colorama
 colorama.init()
 
-USE_CACHE = int(os.environ.get('TLDR_USE_CACHE', '1')) > 0
-MAX_CACHE_AGE = int(os.environ.get('TLDR_MAX_CACHE_AGE', 24))
+USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0
+MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 24))
 
 COMMAND_FILE_REGEX = re.compile(r'(?P<command>^.+?)_(?P<platform>.+?)\.md$')
 

--- a/tldr.py
+++ b/tldr.py
@@ -120,9 +120,9 @@ def have_recent_cache(command, platform):
         return False
 
 
-def get_page_for_platform(command, platform, force_download=False):
+def get_page_for_platform(command, platform):
     data_downloaded = False
-    if not force_download and have_recent_cache(command, platform):
+    if have_recent_cache(command, platform):
         data = load_page_from_cache(command, platform)
     else:
         page_url = remote + "/" + platform + "/" + quote(command) + ".md"
@@ -136,6 +136,12 @@ def get_page_for_platform(command, platform, force_download=False):
     if data_downloaded:
         store_page_to_cache(data, command, platform)
     return data.splitlines()
+
+
+def download_and_store_page_for_platform(command, platform):
+    page_url = remote + "/" + platform + "/" + quote(command) + ".md"
+    data = urlopen(page_url).read()
+    store_page_to_cache(data, command, platform)
 
 
 def get_platform():
@@ -238,8 +244,12 @@ def update_cache():
         match = COMMAND_FILE_REGEX.match(file_name)
         command = match.group('command')
         platform = match.group('platform')
-        get_page_for_platform(command, platform, force_download=True)
-        print('Updated cache for %s (%s)' % (command, platform))
+        try:
+            download_and_store_page_for_platform(command, platform)
+            print('Updated cache for %s (%s)' % (command, platform))
+        except Exception:
+            print('Error: Unable to get %s (%s)' % (command, platform))
+
 
 
 def main():

--- a/tldr.py
+++ b/tldr.py
@@ -17,9 +17,10 @@ from six.moves import map
 import colorama
 colorama.init()
 
+USE_CACHE = int(os.environ.get('TLDR_USE_CACHE', '1')) > 0
+MAX_CACHE_AGE = int(os.environ.get('TLDR_MAX_CACHE_AGE', 24))
 
-USE_CACHE = int(os.environ.get('TLDR_USE_CACHE', '0')) > 0
-MAX_CACHE_AGE = int(os.environ.get('TLDR_MAX_CACHE_AGE', 60))
+COMMAND_FILE_REGEX = re.compile(r'(?P<command>^.+?)_(?P<platform>.+?)\.md$')
 
 
 def get_terminal_size():
@@ -113,15 +114,15 @@ def have_recent_cache(command, platform):
     try:
         cache_file_path = get_cache_file_path(command, platform)
         last_modified = datetime.fromtimestamp(os.path.getmtime(cache_file_path))
-        minutes_passed = (datetime.now() - last_modified).total_seconds() / 60
-        return minutes_passed <= MAX_CACHE_AGE
+        hours_passed = (datetime.now() - last_modified).total_seconds() / 3600
+        return hours_passed <= MAX_CACHE_AGE
     except Exception:
         return False
 
 
-def get_page_for_platform(command, platform):
+def get_page_for_platform(command, platform, force_download=False):
     data_downloaded = False
-    if have_recent_cache(command, platform):
+    if not force_download and have_recent_cache(command, platform):
         data = load_page_from_cache(command, platform)
     else:
         page_url = remote + "/" + platform + "/" + quote(command) + ".md"
@@ -226,8 +227,27 @@ def output(page):
         [cprint(''.ljust(columns), *colors_of('blank')) for i in range(3)]
 
 
+def update_cache():
+    cache_path = os.path.join(os.path.expanduser("~"), ".tldr_cache")
+    if not os.path.exists(cache_path):
+        return
+    files = [file_name for file_name in os.listdir(cache_path)
+             if os.path.isfile(os.path.join(cache_path, file_name)) and
+             COMMAND_FILE_REGEX.match(file_name)]
+    for file_name in files:
+        match = COMMAND_FILE_REGEX.match(file_name)
+        command = match.group('command')
+        platform = match.group('platform')
+        get_page_for_platform(command, platform, force_download=True)
+        print('Updated cache for %s (%s)' % (command, platform))
+
+
 def main():
     parser = ArgumentParser(description="Python command line client for tldr")
+
+    parser.add_argument('-u', '--update_cache',
+                        action='store_true',
+                        help="Update the cached commands")
 
     parser.add_argument('-o', '--os',
                         nargs=1,
@@ -236,10 +256,16 @@ def main():
                         choices=['linux', 'osx', 'sunos'],
                         help="Override the operating system [linux, osx, sunos]")
 
+    options, other_options = parser.parse_known_args()
+
+    if options.update_cache:
+        update_cache()
+        return
+
     parser.add_argument(
         'command', type=str, nargs='+', help="command to lookup")
 
-    options = parser.parse_args()
+    options = parser.parse_args(other_options)
 
     for command in options.command:
         if options.os is not None:

--- a/tldr.py
+++ b/tldr.py
@@ -126,9 +126,9 @@ def get_page_for_platform(command, platform, force_download=False):
         data = load_page_from_cache(command, platform)
     else:
         page_url = remote + "/" + platform + "/" + quote(command) + ".md"
-        data_downloaded = True
         try:
             data = urlopen(page_url).read()
+            data_downloaded = True
         except Exception:
             data = load_page_from_cache(command, platform)
             if data is None:


### PR DESCRIPTION
I didn't like that I always had to wait for 1-3 seconds for the output of the client, so I changed it to load the pages from cache instead of always downloading them. The pages aren't often updated in the main repo, so I think it's alright to load from cache and only update them ever so often.

It's set so that by default it loads from cache, but only if the cache file isn't older than 24 hours. The loading from cache and the max cache age can be set with two new environment variables: `TLDR_CACHE_ENABLED` and `TLDR_CACHE_MAX_AGE`.

Reference #15 and #8 