### PR TITLE
update default colors to match the node client

### DIFF
--- a/tests/data/gem_rendered
+++ b/tests/data/gem_rendered
@@ -1,26 +1,26 @@
-[1m[44m[36m# gem                                                                           [0m
-[44m[37m                                                                                [0m
-[44m[37m  Interact with the package manager for the Ruby programming language.          [0m
-[44m[37m                                                                                [0m
-[44m[32m- Install latest version of a gem                                               [0m
-[44m[37m                                                                                [0m
-[44m[37m  [0m[40m[31mgem install [0m[40m[37mgemname[0m[40m[31m[0m[44m[37m                                                           [0m
-[44m[37m                                                                                [0m
-[44m[32m- Install specific version of a gem                                             [0m
-[44m[37m                                                                                [0m
-[44m[37m  [0m[40m[31mgem install [0m[40m[37mgemname[0m[40m[31m -v [0m[40m[37m1.0.0[0m[40m[31m[0m[44m[37m                                                  [0m
-[44m[37m                                                                                [0m
-[44m[32m- Update a gem                                                                  [0m
-[44m[37m                                                                                [0m
-[44m[37m  [0m[40m[31mgem update [0m[40m[37mgemname[0m[40m[31m[0m[44m[37m                                                            [0m
-[44m[37m                                                                                [0m
-[44m[32m- List all gems                                                                 [0m
-[44m[37m                                                                                [0m
-[44m[37m  [0m[40m[31mgem list[0m[44m[37m                                                                      [0m
-[44m[37m                                                                                [0m
-[44m[32m- Uninstall a gem                                                               [0m
-[44m[37m                                                                                [0m
-[44m[37m  [0m[40m[31mgem uninstall [0m[40m[37mgemname[0m[40m[31m[0m[44m[37m                                                         [0m
-[44m[37m                                                                                [0m
-[44m[37m                                                                                [0m
-[44m[37m                                                                                [0m
+[1m[37m# gem                                                                           [0m
+[37m                                                                                [0m
+[37m  Interact with the package manager for the Ruby programming language.          [0m
+[37m                                                                                [0m
+[32m- Install latest version of a gem                                               [0m
+[37m                                                                                [0m
+[37m  [0m[31mgem install [0m[37mgemname[0m[31m[0m[37m                                                           [0m
+[37m                                                                                [0m
+[32m- Install specific version of a gem                                             [0m
+[37m                                                                                [0m
+[37m  [0m[31mgem install [0m[37mgemname[0m[31m -v [0m[37m1.0.0[0m[31m[0m[37m                                                  [0m
+[37m                                                                                [0m
+[32m- Update a gem                                                                  [0m
+[37m                                                                                [0m
+[37m  [0m[31mgem update [0m[37mgemname[0m[31m[0m[37m                                                            [0m
+[37m                                                                                [0m
+[32m- List all gems                                                                 [0m
+[37m                                                                                [0m
+[37m  [0m[31mgem list[0m[37m                                                                      [0m
+[37m                                                                                [0m
+[32m- Uninstall a gem                                                               [0m
+[37m                                                                                [0m
+[37m  [0m[31mgem uninstall [0m[37mgemname[0m[31m[0m[37m                                                         [0m
+[37m                                                                                [0m
+[37m                                                                                [0m
+[37m                                                                                [0m

--- a/tldr.py
+++ b/tldr.py
@@ -166,12 +166,12 @@ def get_page(command, platform=None):
 
 
 DEFAULT_COLORS = {
-    'blank': 'white on_blue',
-    'name': 'cyan on_blue bold',
-    'description': 'white on_blue',
-    'example': 'green on_blue',
-    'command': 'red on_grey',
-    'parameter': 'white on_grey',
+    'blank': 'white',
+    'name': 'white bold',
+    'description': 'white',
+    'example': 'green',
+    'command': 'red on_black',
+    'parameter': 'white on_black',
 }
 
 LEADING_SPACES_NUM = 2

--- a/tldr.py
+++ b/tldr.py
@@ -170,8 +170,8 @@ DEFAULT_COLORS = {
     'name': 'white bold',
     'description': 'white',
     'example': 'green',
-    'command': 'red on_black',
-    'parameter': 'white on_black',
+    'command': 'red',
+    'parameter': 'white',
 }
 
 LEADING_SPACES_NUM = 2


### PR DESCRIPTION
At the time of writing, the latest version of the node client has the following configuration:
https://github.com/tldr-pages/tldr-node-client/blob/v1.6.0/config.json
