### PR TITLE
Make default remote use HTTPS again

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -16,7 +16,7 @@ from six.moves import map
 # Required for Windows
 import colorama
 
-DEFAULT_REMOTE = "http://raw.github.com/tldr-pages/tldr/master/pages"
+DEFAULT_REMOTE = "https://raw.github.com/tldr-pages/tldr/master/pages"
 USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0
 MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 24))
 


### PR DESCRIPTION
#50 made the remote use HTTPS, but then #42 changed it back to HTTP when adding the flag.