### PR TITLE
Change default remote to use newer raw github path

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -16,7 +16,7 @@ from six.moves import map
 # Required for Windows
 import colorama
 
-DEFAULT_REMOTE = "https://raw.github.com/tldr-pages/tldr/master/pages"
+DEFAULT_REMOTE = "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
 USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0
 MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 24))
 


### PR DESCRIPTION
Some of the *.github.com (like raw) subdomains were "phased out" (they still redirect) in favor of the "githubusercontent.com" subdomains to combat a security issue. This repo should probably utilize these new link styles, even if the old style redirects for most people.

See: https://developer.github.com/changes/2014-04-25-user-content-security/