### PR TITLE
Fix 403 forbidden on --download_cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license='MIT',
     py_modules=['tldr'],
     scripts=['tldr', 'tldr.py'],
-    install_requires=['six', 'termcolor', 'colorama'],
+    install_requires=['six', 'termcolor', 'colorama', 'requests'],
     tests_require=[
         'pytest-runner',
     ],

--- a/tldr.py
+++ b/tldr.py
@@ -10,6 +10,9 @@ from zipfile import ZipFile
 
 from datetime import datetime
 from termcolor import colored, cprint
+
+import requests
+
 from six import BytesIO
 from six.moves.urllib.parse import quote
 from six.moves.urllib.request import urlopen
@@ -284,8 +287,8 @@ def download_cache():
     if not os.path.exists(cache_path):
         return
     try:
-        req = urlopen(DOWNLOAD_CACHE_LOCATION)
-        zipfile = ZipFile(BytesIO(req.read()))
+        req = requests.get(DOWNLOAD_CACHE_LOCATION)
+        zipfile = ZipFile(BytesIO(req.content))
         pattern = re.compile(r'pages/(.+)/(.+)\.md')
         cached = 0
         for entry in zipfile.namelist():


### PR DESCRIPTION
This is a proof of concept for a fix for bug #81. While it works, you probably want to do a bit more:

- use requests everywhere
- replace the Exception
- add some logging

But this PR demonstrate a possible solution for the main issue.