### PR TITLE
Fix path of image in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 A `Python` command line client for [tldr](https://github.com/tldr-pages/tldr).
 
-![tldr screenshot](http://raw.github.com/tldr-pages/tldr/master/screenshot.png)
+![tldr screenshot](http://raw.github.com/tldr-pages/tldr/master/images/screenshot.png)
 
 ## Installation
 


### PR DESCRIPTION
The error seems to have been introduced after [this commit](https://github.com/tldr-pages/tldr/commit/b7c5aefbf8d2886ccb5718e8483c72884b12ec75) on the tldr repo.