### PR TITLE
Allow specifying default remote endpoints using env

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ You can configure the behaviour and output of the `tldr` client by setting envir
     export TLDR_COLOR_PARAMETER="white"
     export TLDR_CACHE_ENABLED=1
     export TLDR_CACHE_MAX_AGE=720
-    export TLDR_REMOTE_SOURCE="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
+    export TLDR_SOURCE="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
     export TLDR_REMOTE_CACHE="https://tldr-pages.github.io/assets/tldr.zip"
 
 ### Cache
@@ -69,7 +69,7 @@ Values of background color and additional effect may be omitted:
 ## Remote source
 
 If you wish to use your own instance of the tldr pages instead of the default repository, you
-can either use the `--source` flag when using tldr or specify the `TLDR_REMOTE_*` environment variables:
+can either use the `--source` flag when using tldr or by specifying the following environment variables:
 
-* `TLDR_REMOTE_SOURCE` to control where to get individual pages from (defaults to `https://raw.githubusercontent.com/tldr-pages/tldr/master/pages`)
+* `TLDR_SOURCE` to control where to get individual pages from (defaults to `https://raw.githubusercontent.com/tldr-pages/tldr/master/pages`)
 * `TLDR_REMOTE_CACHE` to control where to pull a zip of all pages from (defaults to `https://tldr-pages.github.io/assets/tldr.zip`)

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Values of background color and additional effect may be omitted:
 * `TLDR_COLOR_NAME="cyan dark"` for dark cyan text on default system background color
 * `TLDR_COLOR_PARAMETER="red on_yellow underline"` for underlined red text on yellow background
 
-## Remote Source
+## Remote source
 
 If you wish to use your own instance of the tldr pages instead of the default repository, you
 can either use the `--source` flag whne using TLDR or specify the `TLDR_REMOTE_*` environment variables:

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Values of background color and additional effect may be omitted:
 ## Remote source
 
 If you wish to use your own instance of the tldr pages instead of the default repository, you
-can either use the `--source` flag whne using TLDR or specify the `TLDR_REMOTE_*` environment variables:
+can either use the `--source` flag when using tldr or specify the `TLDR_REMOTE_*` environment variables:
 
 * `TLDR_REMOTE_SOURCE` to control where to get individual pages from (defaults to `https://raw.githubusercontent.com/tldr-pages/tldr/master/pages`)
 * `TLDR_REMOTE_CACHE` to control where to pull a zip of all pages from (defaults to `https://tldr-pages.github.io/assets/tldr.zip`)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A `Python` command line client for [tldr](https://github.com/tldr-pages/tldr).
 ### from PyPI
 
     pip install tldr
-    
+
 ### from Arch Linux repository
 
     sudo pacman -S tldr
@@ -36,6 +36,8 @@ You can configure the behaviour and output of the `tldr` client by setting envir
     export TLDR_COLOR_PARAMETER="white"
     export TLDR_CACHE_ENABLED=1
     export TLDR_CACHE_MAX_AGE=720
+    export TLDR_REMOTE_SOURCE="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
+    export TLDR_REMOTE_CACHE="https://tldr-pages.github.io/assets/tldr.zip"
 
 ### Cache
 * `TLDR_CACHE_ENABLED` (default is `1`):
@@ -53,13 +55,21 @@ You can configure the behaviour and output of the `tldr` client by setting envir
 If you are experiencing issues with *tldr*, consider deleting the cache files before trying other measures.
 
 ### Colors
-    
-Values of the `TLDR_COLOR_x` variables may consist of three parts: 
+
+Values of the `TLDR_COLOR_x` variables may consist of three parts:
 * Font color, *required*: `blue, green, yellow, cyan, magenta, white, grey, red`
 * Background color: `on_blue, on_cyan, on_magenta, on_white, on_grey, on_yellow, on_red, on_green`
 * Additional effects, which depends on platform: `reverse, blink, dark, concealed, underline, bold`
 
 Values of background color and additional effect may be omitted:
 * `TLDR_COLOR_DESCRIPTION="white"` for white text on default system background color without any effects
-* `TLDR_COLOR_NAME="cyan dark"` for dark cyan text on default system background color 
+* `TLDR_COLOR_NAME="cyan dark"` for dark cyan text on default system background color
 * `TLDR_COLOR_PARAMETER="red on_yellow underline"` for underlined red text on yellow background
+
+## Remote Source
+
+If you wish to use your own instance of the tldr pages instead of the default repository, you
+can either use the `--source` flag whne using TLDR or specify the `TLDR_REMOTE_*` environment variables:
+
+* `TLDR_REMOTE_SOURCE` to control where to get individual pages from (defaults to `https://raw.githubusercontent.com/tldr-pages/tldr/master/pages`)
+* `TLDR_REMOTE_CACHE` to control where to pull a zip of all pages from (defaults to `https://tldr-pages.github.io/assets/tldr.zip`)

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ You can configure the behaviour and output of the `tldr` client by setting envir
     export TLDR_COLOR_PARAMETER="white"
     export TLDR_CACHE_ENABLED=1
     export TLDR_CACHE_MAX_AGE=720
-    export TLDR_SOURCE="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
-    export TLDR_REMOTE_CACHE="https://tldr-pages.github.io/assets/tldr.zip"
+    export TLDR_PAGES_SOURCE_LOCATION="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
+    export TLDR_DOWNLOAD_CACHE_LOCATION="https://tldr-pages.github.io/assets/tldr.zip"
 
 ### Cache
 * `TLDR_CACHE_ENABLED` (default is `1`):
@@ -71,5 +71,5 @@ Values of background color and additional effect may be omitted:
 If you wish to use your own instance of the tldr pages instead of the default repository, you
 can either use the `--source` flag when using tldr or by specifying the following environment variables:
 
-* `TLDR_SOURCE` to control where to get individual pages from (defaults to `https://raw.githubusercontent.com/tldr-pages/tldr/master/pages`)
-* `TLDR_REMOTE_CACHE` to control where to pull a zip of all pages from (defaults to `https://tldr-pages.github.io/assets/tldr.zip`)
+* `TLDR_PAGES_SOURCE_LOCATION` to control where to get individual pages from (defaults to `https://raw.githubusercontent.com/tldr-pages/tldr/master/pages`)
+* `TLDR_DOWNLOAD_CACHE_LOCATION` to control where to pull a zip of all pages from (defaults to `https://tldr-pages.github.io/assets/tldr.zip`)

--- a/tldr.py
+++ b/tldr.py
@@ -13,7 +13,7 @@ from termcolor import colored, cprint
 from six import BytesIO
 from six.moves.urllib.parse import quote
 from six.moves.urllib.request import urlopen
-from six.moves.urllib.error import HTTPError
+from six.moves.urllib.error import HTTPError, URLError
 from six.moves import map
 # Required for Windows
 import colorama
@@ -21,7 +21,7 @@ import colorama
 PAGES_SOURCE_LOCATION = os.environ.get(
     'TLDR_PAGES_SOURCE_LOCATION',
     'https://raw.githubusercontent.com/tldr-pages/tldr/master/pages'
-)
+).rstrip('/')
 DOWNLOAD_CACHE_LOCATION = os.environ.get(
     'TLDR_DOWNLOAD_CACHE_LOCATION',
     'https://tldr-pages.github.io/assets/tldr.zip'
@@ -181,6 +181,9 @@ def get_page(command, remote=None, platform=None):
             return get_page_for_platform(command, _platform, remote=remote)
         except HTTPError as e:
             if e.code != 404:
+                raise
+        except URLError:
+            if not PAGES_SOURCE_LOCATION.startswith('file://'):
                 raise
 
     return False

--- a/tldr.py
+++ b/tldr.py
@@ -18,10 +18,16 @@ from six.moves import map
 # Required for Windows
 import colorama
 
-DEFAULT_REMOTE = "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
+DEFAULT_REMOTE = os.environ.get(
+    'TLDR_REMOTE_SOURCE',
+    'https://raw.githubusercontent.com/tldr-pages/tldr/master/pages'
+)
 USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0
 MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 24))
-DOWNLOAD_CACHE_LOCATION = 'https://tldr-pages.github.io/assets/tldr.zip'
+DOWNLOAD_CACHE_LOCATION = os.environ.get(
+    'TLDR_REMOTE_CACHE',
+    'https://tldr-pages.github.io/assets/tldr.zip'
+)
 
 COMMAND_FILE_REGEX = re.compile(r'(?P<command>^.+?)_(?P<platform>.+?)\.md$')
 

--- a/tldr.py
+++ b/tldr.py
@@ -19,7 +19,7 @@ from six.moves import map
 import colorama
 
 DEFAULT_REMOTE = os.environ.get(
-    'TLDR_REMOTE_SOURCE',
+    'TLDR_SOURCE',
     'https://raw.githubusercontent.com/tldr-pages/tldr/master/pages'
 )
 USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0

--- a/tldr.py
+++ b/tldr.py
@@ -18,16 +18,16 @@ from six.moves import map
 # Required for Windows
 import colorama
 
-DEFAULT_REMOTE = os.environ.get(
-    'TLDR_SOURCE',
+PAGES_SOURCE_LOCATION = os.environ.get(
+    'TLDR_PAGES_SOURCE_LOCATION',
     'https://raw.githubusercontent.com/tldr-pages/tldr/master/pages'
+)
+DOWNLOAD_CACHE_LOCATION = os.environ.get(
+    'TLDR_DOWNLOAD_CACHE_LOCATION',
+    'https://tldr-pages.github.io/assets/tldr.zip'
 )
 USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0
 MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 24))
-DOWNLOAD_CACHE_LOCATION = os.environ.get(
-    'TLDR_REMOTE_CACHE',
-    'https://tldr-pages.github.io/assets/tldr.zip'
-)
 
 COMMAND_FILE_REGEX = re.compile(r'(?P<command>^.+?)_(?P<platform>.+?)\.md$')
 
@@ -137,7 +137,7 @@ def have_recent_cache(command, platform):
 
 def get_page_url(platform, command, remote=None):
     if remote is None:
-        remote = DEFAULT_REMOTE
+        remote = PAGES_SOURCE_LOCATION
     return remote + "/" + platform + "/" + quote(command) + ".md"
 
 
@@ -324,7 +324,7 @@ def main():
                         help="Override the operating system [linux, osx, sunos, windows, common]")
 
     parser.add_argument('-s', '--source',
-                        default=DEFAULT_REMOTE,
+                        default=PAGES_SOURCE_LOCATION,
                         type=str,
                         help="Override the default page source")
 


### PR DESCRIPTION
Fixes #87 

It was already possible to specify your own source for pulling pages from via the `--source` flag, but this would be cumbersome if you always wanted to use your own source, and never the default. This adds the ability to specify such a default via environment variables, similar to changing the colors and such that `tldr` will use.