### PR TITLE
Set User-Agent header on urlopen requests

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -13,7 +13,7 @@ from termcolor import colored, cprint
 from six import BytesIO
 from six.moves.urllib.parse import quote
 from six.moves.urllib.request import urlopen, Request
-from six.moves.urllib.error import HTTPError
+from six.moves.urllib.error import HTTPError, URLError
 from six.moves import map
 # Required for Windows
 import colorama

--- a/tldr.py
+++ b/tldr.py
@@ -12,7 +12,7 @@ from datetime import datetime
 from termcolor import colored, cprint
 from six import BytesIO
 from six.moves.urllib.parse import quote
-from six.moves.urllib.request import urlopen
+from six.moves.urllib.request import urlopen, Request
 from six.moves.urllib.error import HTTPError
 from six.moves import map
 # Required for Windows
@@ -22,6 +22,8 @@ DEFAULT_REMOTE = "https://raw.githubusercontent.com/tldr-pages/tldr/master/pages
 USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0
 MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 24))
 DOWNLOAD_CACHE_LOCATION = 'https://tldr-pages.github.io/assets/tldr.zip'
+
+REQUEST_HEADERS = {'User-Agent': 'tldr-python-client'}
 
 COMMAND_FILE_REGEX = re.compile(r'(?P<command>^.+?)_(?P<platform>.+?)\.md$')
 
@@ -142,7 +144,7 @@ def get_page_for_platform(command, platform, remote=None):
     else:
         page_url = get_page_url(platform, command, remote)
         try:
-            data = urlopen(page_url).read()
+            data = urlopen(Request(page_url, headers=REQUEST_HEADERS)).read()
             data_downloaded = True
         except Exception:
             data = load_page_from_cache(command, platform)
@@ -155,7 +157,7 @@ def get_page_for_platform(command, platform, remote=None):
 
 def download_and_store_page_for_platform(command, platform, remote=None):
     page_url = get_page_url(platform, command, remote)
-    data = urlopen(page_url).read()
+    data = urlopen(Request(page_url, headers=REQUEST_HEADERS)).read()
     store_page_to_cache(data, command, platform)
 
 
@@ -284,7 +286,10 @@ def download_cache():
     if not os.path.exists(cache_path):
         return
     try:
-        req = urlopen(DOWNLOAD_CACHE_LOCATION)
+        req = urlopen(Request(
+            DOWNLOAD_CACHE_LOCATION,
+            headers=REQUEST_HEADERS
+        ))
         zipfile = ZipFile(BytesIO(req.read()))
         pattern = re.compile(r'pages/(.+)/(.+)\.md')
         cached = 0


### PR DESCRIPTION
Fixes #81 
Closes #82 

Sets the `User-Agent` for urlopen requests. While technically unnecessary when pulling individual pages from GitHub, it's probably still useful to add this in case someone uses a default source that does require it. It is necessary for pulling the zip file as else a 403 forbidden error is returned by the page.