### PR TITLE
Change --update_cache to --update

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -301,7 +301,7 @@ def download_cache():
 def main():
     parser = ArgumentParser(prog="tldr", description="Python command line client for tldr")
 
-    parser.add_argument('-u', '--update_cache',
+    parser.add_argument('-u', '--update',
                         action='store_true',
                         help="Update the cached commands")
 
@@ -342,7 +342,7 @@ def main():
         download_cache()
         return
 
-    if options.update_cache:
+    if options.update:
         update_cache(remote=options.source)
         return
 


### PR DESCRIPTION
The majority of clients that allow to update their cache use --update, this allows to keep a certain unity. One of the consequences encountered with topgrade (utility trying to update the program maximum), not knowing which clients are facing it, it tries the most common method.