### PR TITLE
Improve page resolution strategy to be more inline with spec

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -165,9 +165,17 @@ def get_platform():
             return os_directories[key]
 
 
+def get_platform_list():
+    platforms = ['common'] + list(os_directories.values())
+    current_platform = get_platform()
+    platforms.remove(current_platform)
+    platforms.insert(0, current_platform)
+    return platforms
+
+
 def get_page(command, remote=None, platform=None):
     if platform is None:
-        platform = [get_platform(), "common"]
+        platform = get_platform_list()
     for _platform in platform:
         if _platform is None:
             continue
@@ -362,23 +370,22 @@ def main():
                     output(open_file.read().encode('utf-8').splitlines())
     else:
         try:
-            result = get_page('-'.join(rest.command), platform=options.platform, remote=options.source)
+            command = '-'.join(rest.command)
+            result = get_page(
+                command,
+                platform=options.platform,
+                remote=options.source
+            )
             if not result:
-                errors_found = False
-                for command in rest.command:
-                    result = get_page(command, platform=options.platform, remote=options.source)
-                    if not result:
-                        errors_found = True
-                        print((
-                            "`{cmd}` documentation is not available. "
-                            "Consider contributing Pull Request to https://github.com/tldr-pages/tldr"
-                        ).format(cmd=command), file=sys.stderr)
-                    else:
-                        output(result)
+                print((
+                    "`{cmd}` documentation is not available. "
+                    "Consider contributing Pull Request to https://github.com/tldr-pages/tldr"
+                ).format(cmd=command), file=sys.stderr)
             else:
                 output(result)
         except Exception:
             sys.exit("No internet connection detected. Please reconnect and try again.")
+
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Closes #75 

This change does two things in the name of better following the [client specification for page resolution]https://github.com/tldr-pages/tldr/blob/master/CLIENT-SPECIFICATION.md#page-resolution)(:
1. Gets rid of the weird ambigious parsing issues from #75 (how should `git grep` get parsed? `git` and `grep` or `git-grep`?)
2. Will now search through all supported platforms if no platform is specified instead of only the current platform + common.