### PR TITLE
Add recommendations for light terminal themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ A `Python` command line client for [tldr](https://github.com/tldr-pages/tldr).
 ### from PyPI
 
     pip install tldr
-    
+
 ### from Arch Linux repository
 
     sudo pacman -S tldr
@@ -26,7 +26,8 @@ A `Python` command line client for [tldr](https://github.com/tldr-pages/tldr).
     tldr <command>
 
 ## Configuration
-You can configure the behaviour and output of the `tldr` client by setting environment variables. For example, in the `.bashrc` file:
+
+You can configure the behaviour and output of the `tldr` client by setting environment variables. For example, to set the same as the defaults in the `.bashrc` file:
 
     export TLDR_COLOR_BLANK="white"
     export TLDR_COLOR_NAME="cyan"
@@ -37,7 +38,17 @@ You can configure the behaviour and output of the `tldr` client by setting envir
     export TLDR_CACHE_ENABLED=1
     export TLDR_CACHE_MAX_AGE=720
 
+For light terminal themes, the following colors are recommended:
+
+    export TLDR_COLOR_BLANK="yellow"
+    export TLDR_COLOR_NAME="yellow"
+    export TLDR_COLOR_DESCRIPTION="yellow"
+    export TLDR_COLOR_EXAMPLE="green"
+    export TLDR_COLOR_COMMAND="red"
+    export TLDR_COLOR_PARAMETER="yellow"
+
 ### Cache
+
 * `TLDR_CACHE_ENABLED` (default is `1`):
     * If set to `1`, the client will first try to load from cache, and fall back to fetching from the internet if the cache doesn't exist or is too old.
     * If set to `0`, the client will fetch from the internet, and fall back to the cache if the page cannot be fetched from the internet.
@@ -53,13 +64,13 @@ You can configure the behaviour and output of the `tldr` client by setting envir
 If you are experiencing issues with *tldr*, consider deleting the cache files before trying other measures.
 
 ### Colors
-    
-Values of the `TLDR_COLOR_x` variables may consist of three parts: 
+
+Values of the `TLDR_COLOR_x` variables (see list above) may consist of three parts:
 * Font color, *required*: `blue, green, yellow, cyan, magenta, white, grey, red`
 * Background color: `on_blue, on_cyan, on_magenta, on_white, on_grey, on_yellow, on_red, on_green`
 * Additional effects, which depends on platform: `reverse, blink, dark, concealed, underline, bold`
 
-Values of background color and additional effect may be omitted:
+Examples:
 * `TLDR_COLOR_DESCRIPTION="white"` for white text on default system background color without any effects
-* `TLDR_COLOR_NAME="cyan dark"` for dark cyan text on default system background color 
+* `TLDR_COLOR_NAME="cyan dark"` for dark cyan text on default system background color
 * `TLDR_COLOR_PARAMETER="red on_yellow underline"` for underlined red text on yellow background


### PR DESCRIPTION
Update the README to suggest a color configuration for light terminals themes. With the current default settings, the white text is not legible on most light terminal themes.