### PR TITLE
Use default terminal colors instead of white by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,19 @@ If you are experiencing issues with *tldr*, consider deleting the cache files be
 ### Colors
 
 Values of the `TLDR_COLOR_x` variables may consist of three parts:
-* Font color, *required*: `blue, green, yellow, cyan, magenta, white, grey, red`
+* Font color: `blue, green, yellow, cyan, magenta, white, grey, red`
 * Background color: `on_blue, on_cyan, on_magenta, on_white, on_grey, on_yellow, on_red, on_green`
 * Additional effects, which depends on platform: `reverse, blink, dark, concealed, underline, bold`
 
-Values of background color and additional effect may be omitted:
+You may specify as many additional effects as you want, while only one of font and background color.
+
+Any of the values of above may be omitted. For example, you can do similar things as the following:
+* `TLDR_COLOR_NAME=""` use default system font color with default background color without any effects
 * `TLDR_COLOR_DESCRIPTION="white"` for white text on default system background color without any effects
 * `TLDR_COLOR_NAME="cyan dark"` for dark cyan text on default system background color
+* `TLDR_COLOR_NAME="on_red"` for default system font color on red background color
 * `TLDR_COLOR_PARAMETER="red on_yellow underline"` for underlined red text on yellow background
+* `TLDR_COLOR_NAME="bold underline"` for default system font and background colors with underline and bolded effects
 
 ## Remote source
 

--- a/tests/data/gem_rendered
+++ b/tests/data/gem_rendered
@@ -1,18 +1,18 @@
-[1m[37m# gem                                                                           [0m
+[1m# gem                                                                           [0m
 [37m                                                                                [0m
-[37m  Interact with the package manager for the Ruby programming language.          [0m
+  Interact with the package manager for the Ruby programming language.          [0m
 [37m                                                                                [0m
 [32m- Install latest version of a gem                                               [0m
 [37m                                                                                [0m
-[37m  [0m[31mgem install [0m[37mgemname[0m[31m[0m[37m                                                           [0m
+[37m  [0m[31mgem install [0mgemname[0m[31m[0m[37m                                                           [0m
 [37m                                                                                [0m
 [32m- Install specific version of a gem                                             [0m
 [37m                                                                                [0m
-[37m  [0m[31mgem install [0m[37mgemname[0m[31m -v [0m[37m1.0.0[0m[31m[0m[37m                                                  [0m
+[37m  [0m[31mgem install [0mgemname[0m[31m -v [0m1.0.0[0m[31m[0m[37m                                                  [0m
 [37m                                                                                [0m
 [32m- Update a gem                                                                  [0m
 [37m                                                                                [0m
-[37m  [0m[31mgem update [0m[37mgemname[0m[31m[0m[37m                                                            [0m
+[37m  [0m[31mgem update [0mgemname[0m[31m[0m[37m                                                            [0m
 [37m                                                                                [0m
 [32m- List all gems                                                                 [0m
 [37m                                                                                [0m
@@ -20,7 +20,7 @@
 [37m                                                                                [0m
 [32m- Uninstall a gem                                                               [0m
 [37m                                                                                [0m
-[37m  [0m[31mgem uninstall [0m[37mgemname[0m[31m[0m[37m                                                         [0m
+[37m  [0m[31mgem uninstall [0mgemname[0m[31m[0m[37m                                                         [0m
 [37m                                                                                [0m
 [37m                                                                                [0m
 [37m                                                                                [0m

--- a/tldr.py
+++ b/tldr.py
@@ -193,20 +193,27 @@ def get_page(command, remote=None, platform=None):
 
 DEFAULT_COLORS = {
     'blank': 'white',
-    'name': 'white bold',
-    'description': 'white',
+    'name': 'bold',
+    'description': '',
     'example': 'green',
     'command': 'red',
-    'parameter': 'white',
+    'parameter': '',
 }
 
 # See more details in the README:
 # https://github.com/tldr-pages/tldr-python-client#colors
 ACCEPTED_COLORS = [
     'blue', 'green', 'yellow', 'cyan', 'magenta', 'white',
-    'grey', 'red', 'on_blue', 'on_cyan', 'on_magenta', 'on_white',
-    'on_grey', 'on_yellow', 'on_red', 'on_green', 'reverse',
-    'blink', 'dark', 'concealed', 'underline', 'bold'
+    'grey', 'red'
+]
+
+ACCEPTED_COLOR_BACKGROUNDS = [
+    'on_blue', 'on_cyan', 'on_magenta', 'on_white',
+    'on_grey', 'on_yellow', 'on_red', 'on_green'
+]
+
+ACCEPTED_COLOR_ATTRS = [
+    'reverse', 'blink', 'dark', 'concealed', 'underline', 'bold'
 ]
 
 LEADING_SPACES_NUM = 2
@@ -217,17 +224,18 @@ param_regex = re.compile(r'(?:{{)(?P<param>.+?)(?:}})')
 
 def colors_of(key):
     env_key = 'TLDR_COLOR_%s' % key.upper()
-    user_value = os.environ.get(env_key, '').strip()
-    if user_value and user_value not in ACCEPTED_COLORS:
-        # you can put a warning statement here, but it will print a lot
-        user_value = None
-    values = user_value or DEFAULT_COLORS[key]
-    values = values.split()
-    return (
-        values[0] if len(values) > 0 else None,
-        values[1] if len(values) > 1 and values[1].startswith('on_') else None,
-        values[2:] if len(values) > 1 and values[1].startswith('on_') else values[1:],
-    )
+    values = os.environ.get(env_key, DEFAULT_COLORS[key]).strip().split()
+    color = None
+    on_color = None
+    attrs = []
+    for value in values:
+        if value in ACCEPTED_COLORS:
+            color = value
+        elif value in ACCEPTED_COLOR_BACKGROUNDS:
+            on_color = value
+        elif value in ACCEPTED_COLOR_ATTRS:
+            attrs.append(value)
+    return (color, on_color, attrs)
 
 
 def output(page):


### PR DESCRIPTION
Closes #95 

Closes #94 (sorta)

Removes the white default color from TLDR commands, as well as allows you to specify a blank string for one of the colors and it will work as expected by using the default color from the terminal.

This also fixes an issue where if you could only one word in the environment string and not a combination of things as the `user_value not in ACCEPTED_COLORS` check would always fail otherwise.