### PR TITLE
Drop Python 2 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,36 +1,138 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
 *.py[cod]
+*$py.class
 
 # C extensions
 *.so
 
-# Packages
-*.egg
-*.egg-info
-dist
-build
-eggs
-parts
-bin
-var
-sdist
-develop-eggs
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
 .installed.cfg
-lib
-lib64
-__pycache__
+*.egg
+MANIFEST
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
 
 # Installer logs
 pip-log.txt
+pip-delete-this-directory.txt
 
 # Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
 .coverage
-.tox
+.coverage.*
+.cache
 nosetests.xml
+coverage.xml
+*.cover
+*.py,cover
+.hypothesis/
+.pytest_cache/
+cover/
 
 # Translations
 *.mo
+*.pot
 
-# Mr Developer
-.mr.developer.cfg
-.project
-.pydevproject
+# Django stuff:
+*.log
+local_settings.py
+db.sqlite3
+db.sqlite3-journal
+
+# Flask stuff:
+instance/
+.webassets-cache
+
+# Scrapy stuff:
+.scrapy
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+.pybuilder/
+target/
+
+# Jupyter Notebook
+.ipynb_checkpoints
+
+# IPython
+profile_default/
+ipython_config.py
+
+# pyenv
+#   For a library or package, you might want to ignore these files since the code is
+#   intended to run in multiple environments; otherwise, check them in:
+# .python-version
+
+# pipenv
+#   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.
+#   However, in case of collaboration, if having platform-specific dependencies or dependencies
+#   having no cross-platform support, pipenv may install dependencies that don't work, or not
+#   install all needed dependencies.
+#Pipfile.lock
+
+# PEP 582; used by e.g. github.com/David-OConnor/pyflow
+__pypackages__/
+
+# Celery stuff
+celerybeat-schedule
+celerybeat.pid
+
+# SageMath parsed files
+*.sage.py
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Spyder project settings
+.spyderproject
+.spyproject
+
+# Rope project settings
+.ropeproject
+
+# mkdocs documentation
+/site
+
+# mypy
+.mypy_cache/
+.dmypy.json
+dmypy.json
+
+# Pyre type checker
+.pyre/
+
+# pytype static type analyzer
+.pytype/
+
+# Cython debug symbols
+cython_debug/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,16 @@
 sudo: false
 language: python
 python:
-  - "2.7"
   - "3.4"
   - "3.5"
   - "3.6"
   - "3.7"
   - "3.8"
   - "nightly"
-  - "pypy"
   - "pypy3"
 matrix:
   allow_failures:
     - python: "nightly"
-    - python: "pypy"
     - python: "pypy3"
-install: pip install -U pytest pytest-runner
-script: python setup.py pytest
+install: pip3 install -U pytest pytest-runner
+script: python3 setup.py pytest

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license='MIT',
     py_modules=['tldr'],
     scripts=['tldr', 'tldr.py'],
-    install_requires=['six', 'termcolor', 'colorama'],
+    install_requires=['termcolor', 'colorama'],
     tests_require=[
         'pytest-runner',
     ],
@@ -30,7 +30,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: SunOS/Solaris",
-        "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/tldr.py
+++ b/tldr.py
@@ -1,5 +1,4 @@
-#!/usr/bin/env python
-from __future__ import unicode_literals, print_function, division
+#!/usr/bin/env python3
 import sys
 import os
 import errno
@@ -10,11 +9,10 @@ from zipfile import ZipFile
 
 from datetime import datetime
 from termcolor import colored, cprint
-from six import BytesIO
-from six.moves.urllib.parse import quote
-from six.moves.urllib.request import urlopen, Request
-from six.moves.urllib.error import HTTPError, URLError
-from six.moves import map
+from io import BytesIO
+from urllib.parse import quote
+from urllib.request import urlopen, Request
+from urllib.error import HTTPError, URLError
 # Required for Windows
 import colorama
 


### PR DESCRIPTION
Closes #93.

This should do the job. Note: I updated `.gitignore` to use newer GitHub's template. The main reason was `.eggs` missing from it, which made me stage it in a commit.