### PR TITLE
Improve page display to match the screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ A `Python` command line client for [tldr](https://github.com/tldr-pages/tldr).
 ## Configuration
 You can configure the behaviour and output of the `tldr` client by setting environment variables. For example, in the `.bashrc` file:
 
-    export TLDR_COLOR_BLANK="white"
     export TLDR_COLOR_NAME="cyan"
     export TLDR_COLOR_DESCRIPTION="white"
     export TLDR_COLOR_EXAMPLE="green"

--- a/tests/data/gem_rendered
+++ b/tests/data/gem_rendered
@@ -1,26 +1,20 @@
-[1m# gem                                                                           [0m
-[37m                                                                                [0m
-  Interact with the package manager for the Ruby programming language.          [0m
-[37m                                                                                [0m
-[32m- Install latest version of a gem                                               [0m
-[37m                                                                                [0m
-[37m  [0m[31mgem install [0mgemname[0m[31m[0m[37m                                                           [0m
-[37m                                                                                [0m
-[32m- Install specific version of a gem                                             [0m
-[37m                                                                                [0m
-[37m  [0m[31mgem install [0mgemname[0m[31m -v [0m1.0.0[0m[31m[0m[37m                                                  [0m
-[37m                                                                                [0m
-[32m- Update a gem                                                                  [0m
-[37m                                                                                [0m
-[37m  [0m[31mgem update [0mgemname[0m[31m[0m[37m                                                            [0m
-[37m                                                                                [0m
-[32m- List all gems                                                                 [0m
-[37m                                                                                [0m
-[37m  [0m[31mgem list[0m[37m                                                                      [0m
-[37m                                                                                [0m
-[32m- Uninstall a gem                                                               [0m
-[37m                                                                                [0m
-[37m  [0m[31mgem uninstall [0mgemname[0m[31m[0m[37m                                                         [0m
-[37m                                                                                [0m
-[37m                                                                                [0m
-[37m                                                                                [0m
+
+  [1mgem[0m
+
+  Interact with the package manager for the Ruby programming language.[0m
+
+  [32m- Install latest version of a gem[0m
+    [31mgem install [0mgemname[0m[31m[0m
+
+  [32m- Install specific version of a gem[0m
+    [31mgem install [0mgemname[0m[31m -v [0m1.0.0[0m[31m[0m
+
+  [32m- Update a gem[0m
+    [31mgem update [0mgemname[0m[31m[0m
+
+  [32m- List all gems[0m
+    [31mgem list[0m
+
+  [32m- Uninstall a gem[0m
+    [31mgem uninstall [0mgemname[0m[31m[0m
+

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -10,14 +10,10 @@ class TLDRTests(unittest.TestCase):
             with open("tests/data/gem_rendered", "rb") as f_rendered:
                 old_stdout = sys.stdout
                 sys.stdout = io.StringIO()
-
-                tldr.rows = 24
-                tldr.columns = 80
                 tldr.output(f_original)
 
                 sys.stdout.seek(0)
                 tldr_output = sys.stdout.read().encode("utf-8")
-
                 sys.stdout = old_stdout
 
                 correct_output = f_rendered.read()


### PR DESCRIPTION
Closes #79.

Summary of the changes:
- page format greatly improved
- text properly colored and highlighted
- `blank` color removed
- `cprint` replaced with `colored`
- get terminal size functions removed

Screenshot:
![Screenshot from 2020-04-30 21-58-44](https://user-images.githubusercontent.com/2725611/80753741-11b43280-8b2e-11ea-9d19-b2d78500f4b2.png)