### PR TITLE
Update Travis badge to only consider master branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # tldr-python-client
 
 [![PyPI Release](https://img.shields.io/pypi/v/tldr.svg)](https://pypi.python.org/pypi/tldr)
-[![Build Status](https://travis-ci.org/tldr-pages/tldr-python-client.svg)](https://travis-ci.org/tldr-pages/tldr-python-client)
+[![Build Status](https://travis-ci.org/tldr-pages/tldr-python-client.svg?branch=master)](https://travis-ci.org/tldr-pages/tldr-python-client)
 
 A `Python` command line client for [tldr](https://github.com/tldr-pages/tldr).
 


### PR DESCRIPTION
Otherwise, it will display the status of the last build regardless of branch.