### PR TITLE
add version option to tldr cli

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 setup_dir = Path(__file__).resolve().parent
 version = re.search(
     r'__version__ = "(.*)"',
-    Path(setup_dir, 'tldr.py').read_text()
+    Path(setup_dir, 'tldr.py').open().read()
 )
 if version is None:
     raise SystemExit("Could not determine version to use")

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,16 @@
+from pathlib import Path
+import re
 import sys
 from setuptools import setup
+
+setup_dir = Path(__file__).resolve().parent
+version = re.search(
+    r'__version__ = "(.*)"',
+    Path(setup_dir, 'tldr.py').read_text()
+)
+if version is None:
+    raise SystemExit("Could not determine version to use")
+version = version.group(1)
 
 setup_requires = ['setuptools_scm']
 if sys.argv[-1] in ('sdist', 'bdist_wheel'):
@@ -20,7 +31,7 @@ setup(
         'pytest-runner',
     ],
     setup_requires=setup_requires,
-    use_scm_version=True,
+    version=version,
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",

--- a/tldr.py
+++ b/tldr.py
@@ -12,8 +12,10 @@ from urllib.parse import quote
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError, URLError
 from termcolor import colored
-import colorama # Required for Windows
+import colorama  # Required for Windows
 
+__version__ = "1.0.0"
+__client_specification__ = "1.2"
 
 REQUEST_HEADERS = {'User-Agent': 'tldr-python-client'}
 PAGES_SOURCE_LOCATION = os.environ.get(
@@ -244,6 +246,14 @@ def update_cache():
 
 def main():
     parser = ArgumentParser(prog="tldr", description="Python command line client for tldr")
+    parser.add_argument(
+        '--version',
+        action='version',
+        version='%(prog)s {} (Client Specification {})'.format(
+            __version__,
+            __client_specification__
+        )
+    )
 
     parser.add_argument('-u', '--update_cache',
                         action='store_true',


### PR DESCRIPTION
```bash
$ tldr --version
tldr 1.0.0 (Client Specification 1.2)
```

This also sets the version in setup.py to use whatever is defined in tldr.py instead of pulling it out of source management.