### PR TITLE
add github actions workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: Python application
+
+on:
+  push:
+    branches: [ '*' ]
+  pull_request:
+    branches: [ '*' ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.5', '3.6', '3.7', '3.8', 'pypy3']
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Dependencies
+      run: |
+        python3 -m pip install -U pip
+        python3 -m pip install -U pytest pytest-runner
+
+    - name: Run testsuite
+      run: python3 setup.py pytest

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
     scripts=['tldr', 'tldr.py'],
     install_requires=['termcolor', 'colorama'],
     tests_require=[
+        'pytest',
         'pytest-runner',
     ],
     setup_requires=setup_requires,


### PR DESCRIPTION
This adds a Github Actions workflow to this project, which is identical to Travis-CI with the exception of not testing against Python Nightly. Given the simplicity of the codebase, I don't think this is a real loss of things, with the benefit that GH actions increasingly a nicer platform than Travis-CI beyond a few edge cases.