### PR TITLE
set python_requires to ~=3.5 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ setup(
     ],
     setup_requires=setup_requires,
     version=version,
+    python_requires='~=3.5',
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",
@@ -47,7 +48,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: SunOS/Solaris",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Given that we've moved to GitHub actions, and Python 3.4 was end of life in 2019-03-18, and no current distros ship with it. While the library will probably support 3.4 (and 3.3 and ...) for a while yet, it's not exactly "necessary" to do this, but on the other hand, no point guaranteeing support for a dead version when we hit 1.0 and dropping it would require moving to 2.0.

