### PR TITLE
narrow and print out top-level exception

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -366,8 +366,8 @@ def main():
                 ).format(cmd=command), file=sys.stderr)
             else:
                 output(result)
-        except Exception:
-            sys.exit("No internet connection detected. Please reconnect and try again.")
+        except URLError as e:
+            sys.exit("Error fetching from tldr: {}".format(e))
 
 
 def cli():


### PR DESCRIPTION
Catching `Exception` is not good idiomatic python code, as it can hide errors completely unrelated to what we might want to catch (like syntax errors). The generic error message is also relatively confusing to users considering past bug reports as it's usually that their internet was working totally fine, but just that it was behind a proxy or something. This should make error reporting to us more informative, as well as not hiding unrelated internet things totally as I'd consider that bugs with the program and should not be caught and silenced.