### PR TITLE
improve handling of different languages

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ A `Python` command line client for [tldr](https://github.com/tldr-pages/tldr).
 
 ## Configuration
 
-You can configure the behaviour and output of the `tldr` client by setting environment variables. For example, in the `.bashrc` file:
+You can configure the behavior and output of the `tldr` client by setting environment variables. For example, in the `.bashrc` file:
 
     export TLDR_COLOR_NAME="cyan"
     export TLDR_COLOR_DESCRIPTION="white"
@@ -38,6 +38,7 @@ You can configure the behaviour and output of the `tldr` client by setting envir
     export TLDR_CACHE_MAX_AGE=720
     export TLDR_PAGES_SOURCE_LOCATION="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
     export TLDR_DOWNLOAD_CACHE_LOCATION="https://tldr-pages.github.io/assets/tldr.zip"
+    export TLDR_LANGUAGE="en"
 
 ### Cache
 
@@ -82,7 +83,18 @@ Any of the values of above may be omitted. For example, you can do similar thing
 * `TLDR_COLOR_PARAMETER="red on_yellow underline"` for underlined red text on yellow background
 * `TLDR_COLOR_NAME="bold underline"` for default system font and background colors with underline and bolded effects
 
-## Remote source
+### Language 
+
+The language that tldr will use is dependent on a number of factors. If you specify a language via the
+`--language` flag, tldr will attempt to use that language and only that language. Otherwise, it will
+default to language set using either `TLDR_LANGUAGE` before falling back to `LANG` (ignoring the value `C`).
+If neither are set, then tldr will always attempt to get the `en` page. Finally, if `LANGUAGES` is set, it uses
+this as the priority list to try languages in, with the exception that it will attempt `TLDR_LANGUAGE` and `LANG`
+first, and if neither are set, will use `en` last (assuming it does not already appear somewhere in `LANGUAGES`).
+All language values should be set to a value that follows [RFC 1766](https://tools.ietf.org/html/rfc1766.html),
+with the special exception of `C` which is ignored.
+
+### Remote source
 
 If you wish to use your own instance of the tldr pages instead of the default repository, you
 can either use the `--source` flag when using tldr or by specifying the following environment variables:

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -1,5 +1,6 @@
 import sys
 import io
+import types
 import unittest
 import tldr
 
@@ -10,6 +11,8 @@ class TLDRTests(unittest.TestCase):
             with open("tests/data/gem_rendered", "rb") as f_rendered:
                 old_stdout = sys.stdout
                 sys.stdout = io.StringIO()
+                sys.stdout.buffer = types.SimpleNamespace()
+                sys.stdout.buffer.write = lambda x: sys.stdout.write(x.decode('utf-8'))
                 tldr.output(f_original)
 
                 sys.stdout.seek(0)


### PR DESCRIPTION
The current implementation of languages is a bit simplistic and makes it hard for foreign users to actually use tldr. To start, if `LANG` was set, it's probable that the user would not want to set this just for the sake of tldr. Additionally, there was no support for `LANGUAGES` which goes against the spec.

Anyway, this improves things (imo) to be a bit nicer on the user.

Some examples and full resolution pattern (ignoring platform):
```
TLDR_LANGUAGE=ja python3 tldr.py cd
# checks ja

TLDR_LANGUAGE=fr LANG=es python3 tldr.py cd
# checks fr

LANGUAGES=fr:en TLDR_LANGUAGE=ja LANG=es python3 tldr.py cd
# checks ja, then fr, then en

LANGUAGES=fr:en LANG=C python3 tldr.py cd
# ignores C, checks fr, then en
```

The change to how the page itself was rendered was that setting your `LANG=en` would cause my system to attempt the page in ascii regardless of the resolved language, which would throw an error if printing out non-en pages.