### PR TITLE
Remove unnecessary setup_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,6 @@ if version is None:
     raise SystemExit("Could not determine version to use")
 version = version.group(1)
 
-setup_requires = ['setuptools_scm']
-if sys.argv[-1] in ('sdist', 'bdist_wheel'):
-    setup_requires.append('setuptools-markdown')
-
 setup(
     name='tldr',
     author='Felix Yan',
@@ -36,7 +32,6 @@ setup(
         'pytest',
         'pytest-runner',
     ],
-    setup_requires=setup_requires,
     version=version,
     python_requires='~=3.5',
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from pathlib import Path
 import re
-import sys
 from setuptools import setup
 
 setup_dir = Path(__file__).resolve().parent


### PR DESCRIPTION
Removes the unnecessary `setup_requires` dependencies. The first was used to pull a version from git to use for the client (the version is now specified in code) and the latter was used to parse the README into markdown, which is now handled natively by pypi.