### PR TITLE
expand usage section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,23 @@ A `Python` command line client for [tldr](https://github.com/tldr-pages/tldr).
 
 ## Usage
 
-    tldr <command>
+    usage: tldr [-u] [-p PLATFORM] [-s SOURCE] [-c] [-r] [-L LANGUAGE] command
+
+    Python command line client for tldr
+
+    optional arguments:
+    -h, --help            show this help message and exit
+    -v, --version         show program's version number and exit
+    -u, --update_cache    Update the local cache of pages and exit
+    -p PLATFORM, --platform PLATFORM
+                            Override the operating system [linux, osx, sunos,
+                            windows, common]
+    -s SOURCE, --source SOURCE
+                            Override the default page source
+    -c, --color           Override color stripping
+    -r, --render          Render local markdown files
+    -L LANGUAGE, --language LANGUAGE
+                            Override the default language
 
 ## Configuration
 

--- a/tldr.py
+++ b/tldr.py
@@ -310,6 +310,8 @@ def update_cache(language=None):
 def main():
     parser = ArgumentParser(
         prog="tldr",
+        usage="tldr [-u] [-p PLATFORM] [-s SOURCE] [-c] [-r] [-L LANGUAGE] " +
+        "command",
         description="Python command line client for tldr"
     )
     parser.add_argument(
@@ -358,32 +360,29 @@ def main():
                         type=str,
                         help='Override the default language')
 
-    options, rest = parser.parse_known_args()
+    parser.add_argument(
+        'command', type=str, nargs='*', help="command to lookup"
+    )
+
+    options = parser.parse_args()
 
     colorama.init(strip=options.color)
 
     if options.update_cache:
         update_cache(language=options.language)
         return
-
-    parser.add_argument(
-        'command', type=str, nargs='+', help="command to lookup"
-    )
-
-    if len(sys.argv) == 1:
+    elif len(sys.argv) == 1:
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    rest = parser.parse_args(rest)
-
     if options.render:
-        for command in rest.command:
+        for command in options.command:
             if os.path.exists(command):
                 with open(command, encoding='utf-8') as open_file:
                     output(open_file.read().encode('utf-8').splitlines())
     else:
         try:
-            command = '-'.join(rest.command)
+            command = '-'.join(options.command)
             result = get_page(
                 command,
                 options.source,


### PR DESCRIPTION
Expands the usage section of the README to show the same message as typing `tldr --help`.

The custom string for the `usage` argument of argparse is unfortunate, but it's the only way to get the positional arguments section to show up, while also not showing `command` as totally optional. This is also probably simpler than writing up a custom formatter for argparse.

I could see writing a note below this section to explain the handling of command (e.g. you can type multiple words and will be automatically concatenated (e.g. `git rm` -> `git-rm`) or something.