### PR TITLE
Change empty language string to None in tldr.py

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -162,7 +162,6 @@ def get_language_list():
         lambda x: x.split('_')[0],
         filter(lambda x: x != 'C', languages)
     ))
-    languages = [None if language == '' else language for language in languages]
     if DEFAULT_LANG is not None:
         try:
             languages.remove(DEFAULT_LANG)

--- a/tldr.py
+++ b/tldr.py
@@ -160,7 +160,7 @@ def get_language_list():
     languages = os.environ.get('LANGUAGES', '').split(':')
     languages = list(map(
         lambda x: x.split('_')[0],
-        filter(lambda x: x != 'C', languages)
+        filter(lambda x: not (x == 'C' or x == ''), languages)
     ))
     if DEFAULT_LANG is not None:
         try:

--- a/tldr.py
+++ b/tldr.py
@@ -162,6 +162,7 @@ def get_language_list():
         lambda x: x.split('_')[0],
         filter(lambda x: x != 'C', languages)
     ))
+    languages = [None if language == '' else language for language in languages]
     if DEFAULT_LANG is not None:
         try:
             languages.remove(DEFAULT_LANG)


### PR DESCRIPTION
Tldr.py uses the value None for a language, when no language is set. In line 160 languages is set to '' if no environment is set.
```python
  languages = os.environ.get('LANGUAGES', '').split(':')
```
So the languages list looks like this:
```
['de', '']
```
which results in wrong language handling in line 107 of get_line_url() and a wrong url like
```
https://raw.githubusercontent.com/tldr-pages/tldr/master/pages./linux/unzip.md
```
. My suggested fix is to substitute '' to None.