### PR TITLE
Change language priority for environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,6 @@ You can configure the behavior and output of the `tldr` client by setting enviro
     export TLDR_CACHE_MAX_AGE=720
     export TLDR_PAGES_SOURCE_LOCATION="https://raw.githubusercontent.com/tldr-pages/tldr/master/pages"
     export TLDR_DOWNLOAD_CACHE_LOCATION="https://tldr-pages.github.io/assets/tldr.zip"
-    export TLDR_LANGUAGE="en"
 
 ### Cache
 
@@ -104,16 +103,16 @@ Any of the values of above may be omitted. For example, you can do similar thing
 * `TLDR_COLOR_PARAMETER="red on_yellow underline"` for underlined red text on yellow background
 * `TLDR_COLOR_NAME="bold underline"` for default system font and background colors with underline and bolded effects
 
-### Language 
+### Language
 
 The language that tldr will use is dependent on a number of factors. If you specify a language via the
 `--language` flag, tldr will attempt to use that language and only that language. Otherwise, it will
-default to language set using either `TLDR_LANGUAGE` before falling back to `LANG` (ignoring the value `C`).
-If neither are set, then tldr will always attempt to get the `en` page. Finally, if `LANGUAGES` is set, it uses
-this as the priority list to try languages in, with the exception that it will attempt `TLDR_LANGUAGE` and `LANG`
-first, and if neither are set, will use `en` last (assuming it does not already appear somewhere in `LANGUAGES`).
+default to language set using `LANGUAGE` and `LANG` (ignoring the value `C` and `POSIX`).
+If neither are set, then tldr will always attempt to get the `en` page. Finally, if `LANG` is set, it uses `LANGUAGE`, if set,
+first as the priority list to try languages in, followed by `LANG` if not included in `LANGUAGE`
+and `en` as fallback (assuming it does not already appear somewhere in `LANGUAGES` or `LANG`).
 All language values should be set to a value that follows [RFC 1766](https://tools.ietf.org/html/rfc1766.html),
-with the special exception of `C` which is ignored.
+with the special exception of `C` and `POSIX` which is ignored.
 
 ### Remote source
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ The language that tldr will use is dependent on a number of factors. If you spec
 default to language set using `LANGUAGE` and `LANG` (ignoring the value `C` and `POSIX`).
 If neither are set, then tldr will always attempt to get the `en` page. Finally, if `LANG` is set, it uses `LANGUAGE`, if set,
 first as the priority list to try languages in, followed by `LANG` if not included in `LANGUAGE`
-and `en` as fallback (assuming it does not already appear somewhere in `LANGUAGES` or `LANG`).
+and `en` as fallback (assuming it does not already appear somewhere in `LANGUAGE` or `LANG`).
 All language values should be set to a value that follows [RFC 1766](https://tools.ietf.org/html/rfc1766.html),
 with the special exception of `C` and `POSIX` which is ignored.
 

--- a/tldr.py
+++ b/tldr.py
@@ -15,7 +15,7 @@ from termcolor import colored
 import colorama  # Required for Windows
 
 __version__ = "1.0.0"
-__client_specification__ = "1.2"
+__client_specification__ = "1.3"
 
 REQUEST_HEADERS = {'User-Agent': 'tldr-python-client'}
 PAGES_SOURCE_LOCATION = os.environ.get(

--- a/tldr.py
+++ b/tldr.py
@@ -32,7 +32,7 @@ DEFAULT_LANG = os.environ.get(
     'C'
 ).split('_')[0]
 
-if DEFAULT_LANG == 'C':
+if DEFAULT_LANG == 'C' or DEFAULT_LANG == 'POSIX':
     DEFAULT_LANG = None
 
 USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0
@@ -160,14 +160,14 @@ def get_language_list():
     languages = os.environ.get('LANGUAGE', '').split(':')
     languages = list(map(
         lambda x: x.split('_')[0],
-        filter(lambda x: not (x == 'C' or x == ''), languages)
+        filter(lambda x: not (x == 'C' or x == 'POSIX' or x == ''), languages)
     ))
     if DEFAULT_LANG is not None:
         if DEFAULT_LANG not in languages:
             languages.append(DEFAULT_LANG)
     else:
         languages = []
-    if "en" not in languages:
+    if 'en' not in languages:
         languages.append(None)
     return languages
 

--- a/tldr.py
+++ b/tldr.py
@@ -27,9 +27,14 @@ DOWNLOAD_CACHE_LOCATION = os.environ.get(
     'https://tldr-pages.github.io/assets/tldr.zip'
 )
 
-DEFAULT_LANG = os.environ.get(
+TLDR_LANG = os.environ.get(
     'TLDR_LANGUAGE',
-    os.environ.get('LANG', None)
+    None
+)
+
+DEFAULT_LANG = os.environ.get(
+    'LANG',
+    'C'
 ).split('_')[0]
 
 if DEFAULT_LANG == 'C':
@@ -157,6 +162,8 @@ def get_platform_list():
 
 
 def get_language_list():
+    if TLDR_LANG is not None:
+        return [TLDR_LANG]
     languages = os.environ.get('LANGUAGES', '').split(':')
     languages = list(map(
         lambda x: x.split('_')[0],

--- a/tldr.py
+++ b/tldr.py
@@ -27,11 +27,6 @@ DOWNLOAD_CACHE_LOCATION = os.environ.get(
     'https://tldr-pages.github.io/assets/tldr.zip'
 )
 
-TLDR_LANG = os.environ.get(
-    'TLDR_LANGUAGE',
-    None
-)
-
 DEFAULT_LANG = os.environ.get(
     'LANG',
     'C'
@@ -172,12 +167,6 @@ def get_language_list():
             languages.append(DEFAULT_LANG)
     else:
         languages = []
-    if TLDR_LANG is not None:
-        try:
-            languages.remove(TLDR_LANG)
-        except ValueError:
-            pass
-        languages.insert(0, TLDR_LANG)
     if "en" not in languages:
         languages.append(None)
     return languages

--- a/tldr.py
+++ b/tldr.py
@@ -162,21 +162,24 @@ def get_platform_list():
 
 
 def get_language_list():
-    if TLDR_LANG is not None:
-        return [TLDR_LANG]
     languages = os.environ.get('LANGUAGE', '').split(':')
     languages = list(map(
         lambda x: x.split('_')[0],
         filter(lambda x: not (x == 'C' or x == ''), languages)
     ))
     if DEFAULT_LANG is not None:
+        if DEFAULT_LANG not in languages:
+            languages.append(DEFAULT_LANG)
+    else:
+        languages = []
+    if TLDR_LANG is not None:
         try:
-            languages.remove(DEFAULT_LANG)
+            languages.remove(TLDR_LANG)
         except ValueError:
             pass
-        languages.insert(0, DEFAULT_LANG)
-    else:
-        languages.append('en')
+        languages.insert(0, TLDR_LANG)
+    if "en" not in languages:
+        languages.append(None)
     return languages
 
 


### PR DESCRIPTION
Regarding the language priority discussed in #122 and  tldr-pages/tldr#4101 I have implemented a solution. My suggestion would be a priority like that
| TLDR_LANGUAGE | LANG | LANGUAGES | Result |
| --- | --- | --- | --- |
| fr | de | it,fr,de | fr |
| ! | de | it,fr,de | de,it,fr,en |
| ! | ! | it,fr,de | it,fr,de,en |
| ! | de | ! | de,en |

, while ! is unset.

I'm also interested, where LANGUAGES originates from. While I couldn't find a notion of it in the archwiki, or at [gnu.org](https://www.gnu.org/software/gettext/manual/html_node/Locale-Environment-Variables.html#Locale-Environment-Variables), I found the LANGUAGE environment variable instead.

Since this topic is still in discussion I'm submitting this as a draft in case it could be useful.