### PR TITLE
Fix env variable from LANGUAGES to LANGUAGE

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -157,7 +157,7 @@ def get_platform_list():
 
 
 def get_language_list():
-    languages = os.environ.get('LANGUAGES', '').split(':')
+    languages = os.environ.get('LANGUAGE', '').split(':')
     languages = list(map(
         lambda x: x.split('_')[0],
         filter(lambda x: not (x == 'C' or x == ''), languages)


### PR DESCRIPTION
Typo on my part from a prior PR, this should be `LANGUAGE` (since it refers to https://www.gnu.org/software/gettext/manual/html_node/The-LANGUAGE-variable.html#The-LANGUAGE-variable), and not `LANGUAGES`.