### PR TITLE
Add autocomplete and --list option for listing commands (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ optional arguments:
                         Override the default page source
   -c, --color           Override color stripping
   -r, --render          Render local markdown files
+  -l, --list            List all available commands for operating system    
   -L LANGUAGE, --language LANGUAGE
                         Override the default language
 ```
@@ -78,6 +79,10 @@ In order of precedence:
 * `~/.cache/tldr`
 
 If you are experiencing issues with *tldr*, consider deleting the cache files before trying other measures.
+
+#### Autocomplete
+
+`argcomplete` is required for autocompletion. See the `argcomplete` [docs](https://pypi.org/project/argcomplete/) for how to enable `argcomplete`. Cache will also need to be enabled and downloaded.
 
 ### SSL Inspection
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
             "tldr = tldr:cli"
         ]
     },
-    install_requires=['termcolor', 'colorama'],
+    install_requires=['termcolor', 'colorama', 'argcomplete'],
     tests_require=[
         'pytest',
         'pytest-runner',

--- a/tldr.py
+++ b/tldr.py
@@ -227,7 +227,10 @@ PARAM_REGEX = re.compile(r'(?:{{)(?P<param>.+?)(?:}})')
 CACHE_FILE_REGEX = re.compile(r'.*\/(.*)\.md')
 
 
-def get_commands(platforms=['**']):
+def get_commands(platforms=None):
+    if platforms is None:
+        platforms = get_platform_list()
+
     cache_files = []
     for platform in platforms:
         cache_files += glob(os.path.join(get_cache_dir(), 'pages', platform, '*.md'))
@@ -396,8 +399,7 @@ def main():
         sys.exit(1)
 
     if options.list:
-        platform = options.platform or ['**']
-        print(get_commands(platform))
+        print(get_commands(options.platform))
     elif options.render:
         for command in options.command:
             if os.path.exists(command):

--- a/tldr.py
+++ b/tldr.py
@@ -228,8 +228,9 @@ CACHE_FILE_REGEX = re.compile(r'.*\/(.*)\.md')
 
 
 def get_commands(platforms=['**']):
+    cache_files = []
     for platform in platforms:
-        cache_files = glob(os.path.join(get_cache_dir(), 'pages', platform, '*.md'))
+        cache_files += glob(os.path.join(get_cache_dir(), 'pages', platform, '*.md'))
     return [re.search(CACHE_FILE_REGEX, x).group(1) for x in cache_files]
 
 

--- a/tldr.py
+++ b/tldr.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+# PYTHON_ARGCOMPLETE_OK
 
 import sys
 import os
@@ -13,6 +14,8 @@ from urllib.request import urlopen, Request
 from urllib.error import HTTPError, URLError
 from termcolor import colored
 import colorama  # Required for Windows
+import argcomplete
+from glob import glob
 
 __version__ = "1.0.0"
 __client_specification__ = "1.2"
@@ -221,6 +224,13 @@ LEADING_SPACES_NUM = 2
 
 COMMAND_SPLIT_REGEX = re.compile(r'(?P<param>{{.+?}})')
 PARAM_REGEX = re.compile(r'(?:{{)(?P<param>.+?)(?:}})')
+CACHE_FILE_REGEX = re.compile(r'.*\/(.*)\.md')
+
+
+def get_commands(platforms=['**']):
+    for platform in platforms:
+        cache_files = glob(os.path.join(get_cache_dir(), 'pages', platform, '*.md'))
+    return [re.search(CACHE_FILE_REGEX, x).group(1) for x in cache_files]
 
 
 def colors_of(key):
@@ -312,7 +322,7 @@ def update_cache(language=None):
 def main():
     parser = ArgumentParser(
         prog="tldr",
-        usage="tldr [-u] [-p PLATFORM] [-s SOURCE] [-c] [-r] [-L LANGUAGE] " +
+        usage="tldr [-u] [-p PLATFORM] [-l] [-s SOURCE] [-c] [-r] [-L LANGUAGE]" +
         "command",
         description="Python command line client for tldr"
     )
@@ -339,6 +349,11 @@ def main():
         help="Override the operating system [linux, osx, sunos, windows, common]"
     )
 
+    parser.add_argument('-l', '--list',
+                        default=False,
+                        action='store_true',
+                        help="List all available commands for operating system")
+
     parser.add_argument('-s', '--source',
                         default=PAGES_SOURCE_LOCATION,
                         type=str,
@@ -363,9 +378,11 @@ def main():
                         help='Override the default language')
 
     parser.add_argument(
-        'command', type=str, nargs='*', help="command to lookup"
+        'command', type=str, nargs='*', help="command to lookup", metavar='command',
+        choices=get_commands() + [[]]
     )
 
+    argcomplete.autocomplete(parser)
     options = parser.parse_args()
 
     colorama.init(strip=options.color)
@@ -377,7 +394,10 @@ def main():
         parser.print_help(sys.stderr)
         sys.exit(1)
 
-    if options.render:
+    if options.list:
+        platform = options.platform or ['**']
+        print(get_commands(platform))
+    elif options.render:
         for command in options.command:
             if os.path.exists(command):
                 with open(command, encoding='utf-8') as open_file:


### PR DESCRIPTION
Closes #69 

Hi! I was interested in the autocomplete feature, so I took a stab at implementing it. It didn't take much extra effort to add a --list option to list available commands for the platform, so I did that as well, seeing that the node client has one. I'm pretty new to contributing to opensource projects, so any suggestions are greatly appreciated :)

argcomplete was acting a little bit finicky on my local dev environment, so it'll be great if one of the maintainers can try it out to make sure it works fine as well. 

Thank you for this great client!