### PR TITLE
Make client work without internet

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -419,7 +419,6 @@ def main():
             options.platform,
             options.language
         )
-        print(result)
         if result.get("entry"):
             output(result['entry'])
         elif result['error']:

--- a/tldr.py
+++ b/tldr.py
@@ -191,8 +191,10 @@ def get_page(command, remote=None, platforms=None, languages=None):
                         command,
                         platform,
                         remote,
-                        language),
-                    "error": False}
+                        language
+                    ),
+                    "error": False
+                }
             except HTTPError as err:
                 if err.code != 404:
                     returnErr = {"entry": err, "error": True}

--- a/tldr.py
+++ b/tldr.py
@@ -419,10 +419,10 @@ def main():
             options.platform,
             options.language
         )
-        if result.get("entry"):
+        if result['error']:
+            sys.exit("Error fetching from tldr: {}".format(result['entry']))
+        elif result.get("entry"):
             output(result['entry'])
-        elif result['error']:
-            sys.exit("Error fetching from tldr: {}".format(result['error']))
         else:
             sys.exit((
                 "`{cmd}` documentation is not available. "

--- a/tldr.py
+++ b/tldr.py
@@ -187,11 +187,9 @@ def get_page(command, remote=None, platforms=None, languages=None):
             try:
                 return get_page_for_platform(command, platform, remote, language)
             except HTTPError as err:
-                if err.code != 404:
-                    raise
+                pass
             except URLError:
-                if not PAGES_SOURCE_LOCATION.startswith('file://'):
-                    pass
+                pass
 
     return False
 

--- a/tldr.py
+++ b/tldr.py
@@ -176,6 +176,7 @@ def get_language_list():
 
 
 def get_page(command, remote=None, platforms=None, languages=None):
+    returnErr = {}
     if platforms is None:
         platforms = get_platform_list()
     if languages is None:
@@ -185,13 +186,21 @@ def get_page(command, remote=None, platforms=None, languages=None):
             if platform is None:
                 continue
             try:
-                return get_page_for_platform(command, platform, remote, language)
+                return {"entry": get_page_for_platform(command, platform, remote, language), "error": False}
             except HTTPError as err:
+<<<<<<< Updated upstream
                 pass
             except URLError:
                 pass
+=======
+                if err.code != 404:
+                    returnErr = {"entry": err, "error": True}
+            except URLError as err:
+                if not PAGES_SOURCE_LOCATION.startswith('file://'):
+                    returnErr = {"entry": err, "error": True}
+>>>>>>> Stashed changes
 
-    return False
+    return returnErr
 
 
 DEFAULT_COLORS = {
@@ -403,6 +412,7 @@ def main():
                 with open(command, encoding='utf-8') as open_file:
                     output(open_file.read().encode('utf-8').splitlines())
     else:
+<<<<<<< Updated upstream
         try:
             command = '-'.join(options.command)
             result = get_page(
@@ -420,7 +430,26 @@ def main():
             else:
                 output(result)
         except URLError as e:
+=======
+        command = '-'.join(options.command)
+        result = get_page(
+            command,
+            options.source,
+            options.platform,
+            options.language
+        )
+        print(result)
+        if result.get("entry"):
+            output(result['entry'])
+        elif result['error']:
+>>>>>>> Stashed changes
             sys.exit("Error fetching from tldr: {}".format(e))
+        else:
+            sys.exit((
+                "`{cmd}` documentation is not available. "
+                "Consider contributing Pull Request to "
+                "https://github.com/tldr-pages/tldr"
+            ).format(cmd=command))
 
 
 def cli():

--- a/tldr.py
+++ b/tldr.py
@@ -188,10 +188,10 @@ def get_page(command, remote=None, platforms=None, languages=None):
                 return get_page_for_platform(command, platform, remote, language)
             except HTTPError as err:
                 if err.code != 404:
-                    continue
+                    raise
             except URLError:
                 if not PAGES_SOURCE_LOCATION.startswith('file://'):
-                    continue
+                    pass
 
     return False
 

--- a/tldr.py
+++ b/tldr.py
@@ -75,8 +75,8 @@ def load_page_from_cache(command, platform, language):
         with open(get_cache_file_path(
             command,
             platform,
-            language), 'rb'
-        ) as cache_file:
+            language
+        ), 'rb') as cache_file:
             cache_file_contents = cache_file.read()
         return cache_file_contents
     except Exception:

--- a/tldr.py
+++ b/tldr.py
@@ -186,19 +186,19 @@ def get_page(command, remote=None, platforms=None, languages=None):
             if platform is None:
                 continue
             try:
-                return {"entry": get_page_for_platform(command, platform, remote, language), "error": False}
+                return {
+                    "entry": get_page_for_platform(
+                        command,
+                        platform,
+                        remote,
+                        language),
+                    "error": False}
             except HTTPError as err:
-<<<<<<< Updated upstream
-                pass
-            except URLError:
-                pass
-=======
                 if err.code != 404:
                     returnErr = {"entry": err, "error": True}
             except URLError as err:
                 if not PAGES_SOURCE_LOCATION.startswith('file://'):
                     returnErr = {"entry": err, "error": True}
->>>>>>> Stashed changes
 
     return returnErr
 
@@ -412,25 +412,6 @@ def main():
                 with open(command, encoding='utf-8') as open_file:
                     output(open_file.read().encode('utf-8').splitlines())
     else:
-<<<<<<< Updated upstream
-        try:
-            command = '-'.join(options.command)
-            result = get_page(
-                command,
-                options.source,
-                options.platform,
-                options.language
-            )
-            if not result:
-                print((
-                    "`{cmd}` documentation is not available. "
-                    "Consider contributing Pull Request to "
-                    "https://github.com/tldr-pages/tldr"
-                ).format(cmd=command), file=sys.stderr)
-            else:
-                output(result)
-        except URLError as e:
-=======
         command = '-'.join(options.command)
         result = get_page(
             command,
@@ -442,8 +423,7 @@ def main():
         if result.get("entry"):
             output(result['entry'])
         elif result['error']:
->>>>>>> Stashed changes
-            sys.exit("Error fetching from tldr: {}".format(e))
+            sys.exit("Error fetching from tldr: {}".format(result['error']))
         else:
             sys.exit((
                 "`{cmd}` documentation is not available. "

--- a/tldr.py
+++ b/tldr.py
@@ -188,10 +188,10 @@ def get_page(command, remote=None, platforms=None, languages=None):
                 return get_page_for_platform(command, platform, remote, language)
             except HTTPError as err:
                 if err.code != 404:
-                    raise
+                    continue
             except URLError:
                 if not PAGES_SOURCE_LOCATION.startswith('file://'):
-                    raise
+                    continue
 
     return False
 
@@ -269,7 +269,7 @@ def output(page):
                     colored(
                         line.replace('>', '').replace('<', ''),
                         *colors_of('description')
-                    )
+                )
                 sys.stdout.buffer.write(line.encode('utf-8'))
             elif line[0] == '-':
                 line = '\n' + ' ' * LEADING_SPACES_NUM + \

--- a/tldr.py
+++ b/tldr.py
@@ -440,5 +440,3 @@ def cli():
 
 if __name__ == "__main__":
     cli()
-y'])
-        else:

--- a/tldr.py
+++ b/tldr.py
@@ -419,7 +419,7 @@ def main():
             options.platform,
             options.language
         )
-        if result['error']:
+        if result.get('error'):
             sys.exit("Error fetching from tldr: {}".format(result['entry']))
         elif result.get("entry"):
             output(result['entry'])
@@ -440,3 +440,5 @@ def cli():
 
 if __name__ == "__main__":
     cli()
+y'])
+        else:


### PR DESCRIPTION
Currently the client fails when running a command without internet, even when the command is cached. For example, `tldr df` with internet disconnected returns
> Error fetching from tldr: <urlopen error [Errno -3] Temporary failure in name resolution>