### PR TITLE
Fix "documentation is not available.", refactor get_commands

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python3 -m pip install -U pip
-        python3 -m pip install -U pytest pytest-runner flake8
+        python3 -m pip install -U pytest pytest-runner flake8 mock
 
     - name: Lint codebase
       run: python3 -m flake8

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
     - name: Install Dependencies
       run: |
         python3 -m pip install -U pip
-        python3 -m pip install -U pytest pytest-runner flake8 mock
+        python3 -m pip install -U pytest pytest-runner flake8
 
     - name: Lint codebase
       run: python3 -m flake8

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -2,9 +2,9 @@ import sys
 import io
 import types
 import unittest
+import unittest.mock
 import tldr
 import pytest
-from mock import patch
 
 
 class TLDRTests(unittest.TestCase):
@@ -25,8 +25,7 @@ class TLDRTests(unittest.TestCase):
                 self.assertEqual(tldr_output, correct_output)
 
     def test_error_message(self):
-        testargs = ["tldr", "73eb6f19cd6f"]
-        with patch.object(sys, "argv", testargs):
+        with unittest.mock.patch("sys.argv", ["tldr", "73eb6f19cd6f"]):
             with pytest.raises(SystemExit) as pytest_wrapped_e:
                 tldr.main()
             correct_output = "`73eb6f19cd6f` documentation is not available. Consider contributing Pull Request to https://github.com/tldr-pages/tldr"  # noqa

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -3,6 +3,8 @@ import io
 import types
 import unittest
 import tldr
+import pytest
+from mock import patch
 
 
 class TLDRTests(unittest.TestCase):
@@ -12,7 +14,7 @@ class TLDRTests(unittest.TestCase):
                 old_stdout = sys.stdout
                 sys.stdout = io.StringIO()
                 sys.stdout.buffer = types.SimpleNamespace()
-                sys.stdout.buffer.write = lambda x: sys.stdout.write(x.decode('utf-8'))
+                sys.stdout.buffer.write = lambda x: sys.stdout.write(x.decode("utf-8"))
                 tldr.output(f_original)
 
                 sys.stdout.seek(0)
@@ -21,3 +23,13 @@ class TLDRTests(unittest.TestCase):
 
                 correct_output = f_rendered.read()
                 self.assertEqual(tldr_output, correct_output)
+
+    def test_error_message(self):
+        testargs = ["tldr", "73eb6f19cd6f"]
+        with patch.object(sys, "argv", testargs):
+            with pytest.raises(SystemExit) as pytest_wrapped_e:
+                tldr.main()
+            correct_output = "`73eb6f19cd6f` documentation is not available. Consider contributing Pull Request to https://github.com/tldr-pages/tldr"  # noqa
+            print("Test {}".format(pytest_wrapped_e))
+            assert pytest_wrapped_e.type == SystemExit
+            assert str(pytest_wrapped_e.value) == correct_output

--- a/tldr.py
+++ b/tldr.py
@@ -229,9 +229,10 @@ def get_commands(platforms=None):
         platforms = get_platform_list()
 
     commands = []
-    for platform in platforms:
-        path = os.path.join(get_cache_dir(), 'pages', platform)
-        commands += [file[:-3] for file in os.listdir(path) if file.endswith(".md")]
+    if os.path.exists(get_cache_dir()):
+        for platform in platforms:
+            path = os.path.join(get_cache_dir(), 'pages', platform)
+            commands += [file[:-3] for file in os.listdir(path) if file.endswith(".md")]
     return commands
 
 

--- a/tldr.py
+++ b/tldr.py
@@ -15,6 +15,7 @@ from urllib.error import HTTPError, URLError
 from termcolor import colored
 import colorama  # Required for Windows
 from argcomplete.completers import ChoicesCompleter
+import argcomplete
 from glob import glob
 
 __version__ = "1.0.0"
@@ -383,6 +384,8 @@ def main():
     parser.add_argument(
         'command', type=str, nargs='*', help="command to lookup", metavar='command'
     ).completer = ChoicesCompleter(get_commands() + [[]])
+
+    argcomplete.autocomplete(parser)
 
     options = parser.parse_args()
 

--- a/tldr.py
+++ b/tldr.py
@@ -15,7 +15,6 @@ from urllib.error import HTTPError, URLError
 from termcolor import colored
 import colorama  # Required for Windows
 import argcomplete
-from glob import glob
 
 __version__ = "1.0.0"
 __client_specification__ = "1.3"
@@ -223,17 +222,17 @@ LEADING_SPACES_NUM = 2
 
 COMMAND_SPLIT_REGEX = re.compile(r'(?P<param>{{.+?}})')
 PARAM_REGEX = re.compile(r'(?:{{)(?P<param>.+?)(?:}})')
-CACHE_FILE_REGEX = re.compile(r'.*\/(.*)\.md')
 
 
 def get_commands(platforms=None):
     if platforms is None:
         platforms = get_platform_list()
 
-    cache_files = []
+    commands = []
     for platform in platforms:
-        cache_files += glob(os.path.join(get_cache_dir(), 'pages', platform, '*.md'))
-    return [re.search(CACHE_FILE_REGEX, x).group(1) for x in cache_files]
+        path = os.path.join(get_cache_dir(), 'pages', platform)
+        commands += [file[:-3] for file in os.listdir(path) if file.endswith(".md")]
+    return commands
 
 
 def colors_of(key):

--- a/tldr.py
+++ b/tldr.py
@@ -14,7 +14,7 @@ from urllib.request import urlopen, Request
 from urllib.error import HTTPError, URLError
 from termcolor import colored
 import colorama  # Required for Windows
-import argcomplete
+from argcomplete.completers import ChoicesCompleter
 from glob import glob
 
 __version__ = "1.0.0"
@@ -269,7 +269,7 @@ def output(page):
                     colored(
                         line.replace('>', '').replace('<', ''),
                         *colors_of('description')
-                    )
+                )
                 sys.stdout.buffer.write(line.encode('utf-8'))
             elif line[0] == '-':
                 line = '\n' + ' ' * LEADING_SPACES_NUM + \
@@ -381,11 +381,9 @@ def main():
                         help='Override the default language')
 
     parser.add_argument(
-        'command', type=str, nargs='*', help="command to lookup", metavar='command',
-        choices=get_commands() + [[]]
-    )
+        'command', type=str, nargs='*', help="command to lookup", metavar='command'
+    ).completer = ChoicesCompleter(get_commands() + [[]])
 
-    argcomplete.autocomplete(parser)
     options = parser.parse_args()
 
     colorama.init(strip=options.color)

--- a/tldr.py
+++ b/tldr.py
@@ -14,7 +14,6 @@ from urllib.request import urlopen, Request
 from urllib.error import HTTPError, URLError
 from termcolor import colored
 import colorama  # Required for Windows
-from argcomplete.completers import ChoicesCompleter
 import argcomplete
 from glob import glob
 
@@ -383,7 +382,7 @@ def main():
 
     parser.add_argument(
         'command', type=str, nargs='*', help="command to lookup", metavar='command'
-    ).completer = ChoicesCompleter(get_commands() + [[]])
+    ).completer = argcomplete.completers.ChoicesCompleter(get_commands() + [[]])
 
     argcomplete.autocomplete(parser)
 

--- a/tldr.py
+++ b/tldr.py
@@ -385,7 +385,6 @@ def main():
     ).completer = argcomplete.completers.ChoicesCompleter(get_commands() + [[]])
 
     argcomplete.autocomplete(parser)
-
     options = parser.parse_args()
 
     colorama.init(strip=options.color)


### PR DESCRIPTION
I found this bug while testing #130. Added a testcase for the future.

Sped up get_commands about 5x, tested with
```
import time
start_time = time.time_ns()
for i in range(100):
    get_commands()
print("Time: {}".format(time.time_ns()-start_time))
```

Fixes #131 