### PR TITLE
remove empty list option from autocomplete

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -395,7 +395,7 @@ def main():
 
     parser.add_argument(
         'command', type=str, nargs='*', help="command to lookup", metavar='command'
-    ).completer = argcomplete.completers.ChoicesCompleter(get_commands() + [[]])
+    ).completer = argcomplete.completers.ChoicesCompleter(get_commands())
 
     argcomplete.autocomplete(parser)
     options = parser.parse_args()


### PR DESCRIPTION
This removes the `+ [[]]` from the autocomplete for commands as it was being appended to the list of options and could then be selected by tabbing till hitting it, which then leads to an error. Given the changes from #132, it seems like this is no longer necessary, though will test this further on bash tomorrow when I'm not traveling.