### PR TITLE
Try to get tldr in $LANG, fallback to en

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -426,6 +426,13 @@ def main():
                 options.language
             )
             if not result:
+                result = get_page(
+                    command,
+                    options.source,
+                    options.platform,
+                    "en"
+                )
+            if not result:
                 sys.exit((
                     "`{cmd}` documentation is not available. "
                     "Consider contributing Pull Request to "


### PR DESCRIPTION
This MR adds a fallback to english when a TL;DR has not been found in requested language