### PR TITLE
Support for offline usage (pages needs to be cached first).

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -200,8 +200,9 @@ def get_page(command, remote=None, platforms=None, languages=None):
                 if err.code != 404:
                     raise
             except URLError:
-                if not PAGES_SOURCE_LOCATION.startswith('file://'):
-                    raise
+                if (platform == "common" and (not (language and language != 'en'))):
+                    if not PAGES_SOURCE_LOCATION.startswith('file://'):
+                        raise
 
     return False
 


### PR DESCRIPTION
When directly connect with remote repos, or setting
`TLDR_PAGES_SOURCE_LOCATION` with `file://` protocol, it always gives
following error instantly:

```
Error fetching from tldr: <urlopen error [Errno 111] Connection
refused>
```

So i have download the tldr.zip using Chrome from
`https://tldr-pages.github.io/assets/tldr.zip`, to install it:

```shell
$ cd /directory/of/downloaded_tldr_zip
$ python2 -m SimpleHTTPServer 8000
$ DOWNLOAD_CACHE_LOCATION=127.0.0.1:8000/tldr.zip tldr --update_cache
```

When run `tldr cd` command on Linux, because in China, network are
always issues when accessing foreign website.

It always gives me network error, even though the document is
available at `tldr/pages/common/cd.md`, but exit with error at
platform with `linux`, for example `tldr/pages/linux/cd.md`, without
iterate all possible PLATFORM and LANGUAGE first.