### PR TITLE
Set --help usage line to match node client

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -346,7 +346,7 @@ def main():
     parser = ArgumentParser(
         prog="tldr",
         usage="tldr command [options]",
-        description="Simplified and community-driven man pages"
+        description="Python command line client for tldr"
     )
     parser.add_argument(
         '-v', '--version',

--- a/tldr.py
+++ b/tldr.py
@@ -345,9 +345,8 @@ def update_cache(language=None):
 def main():
     parser = ArgumentParser(
         prog="tldr",
-        usage="tldr [-u] [-p PLATFORM] [-l] [-s SOURCE] [-c] [-r] [-L LANGUAGE]" +
-        " command",
-        description="Python command line client for tldr"
+        usage="tldr command [options]",
+        description="Simplified and community-driven man pages"
     )
     parser.add_argument(
         '-v', '--version',


### PR DESCRIPTION
The current usage text for the client is:
```
usage: tldr [-u] [-p PLATFORM] [-l] [-s SOURCE] [-c] [-r] [-L LANGUAGE] command
```

This works, but is cumbersome to add more options to as the string is manually configured, and making sure the flags match their string, etc.

The switch for using the manually created string instead of relying on argparse was done in #116, with the reason that `command` would show up as optional and many part (`[command, ...]`) because of the `nargs='*'` on it. This is confusing though as `command` is only optional when using `--update_cache`, and then otherwise required. Hence the manually set string.

The node client on the other hand does:
```
Usage: tldr command [options]
```

This is preferable imo to our current approach as we then let argparse to show our options below automatically and we should never have to touch the usage string again.