### PR TITLE
Drop support for Python 3.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy3']
 
     steps:
     - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         'pytest-runner',
     ],
     version=version,
-    python_requires='~=3.5',
+    python_requires='~=3.6',
     classifiers=[
         "Development Status :: 4 - Beta",
         "License :: OSI Approved :: MIT License",
@@ -42,7 +42,6 @@ setup(
         "Operating System :: POSIX :: Linux",
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: SunOS/Solaris",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",


### PR DESCRIPTION
As per [suggestion by bl-ue](https://github.com/tldr-pages/tldr-python-client/pull/157#issuecomment-835461760) (thanks!), remove support for Python 3.5 since it is EOL