### PR TITLE
docs: update to use new screenshot link

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 Python command-line client for [tldr pages](https://github.com/tldr-pages/tldr).
 
-![tldr screenshot](http://raw.github.com/tldr-pages/tldr/master/images/screenshot.png)
+![tldr pages example](https://raw.github.com/tldr-pages/tldr/main/images/tldr.svg)
 
 ## Installation
 


### PR DESCRIPTION
Looks like a new animated SVG was introduced in https://github.com/tldr-pages/tldr/pull/5507 which removed the old `screenshot.png` link.

Not sure if the size is an issue and we should be shrinking this down, but let me know or feel free to apply size changes. 👍🏻

Closes https://github.com/tldr-pages/tldr-python-client/issues/160