### PR TITLE
Improve wording of missing page error message

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length=100
+max-line-length=88

--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,2 @@
 [flake8]
-max-line-length=88
+max-line-length=100

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -27,7 +27,7 @@ def test_error_message():
     with mock.patch("sys.argv", ["tldr", "73eb6f19cd6f"]):
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             tldr.main()
-        correct_output = "`73eb6f19cd6f` documentation is not available. Consider contributing Pull Request to https://github.com/tldr-pages/tldr"  # noqa
+        correct_output = "`73eb6f19cd6f` documentation is not available. Consider contributing a pull request to https://github.com/tldr-pages/tldr"  # noqa
         print("Test {}".format(pytest_wrapped_e))
         assert pytest_wrapped_e.type == SystemExit
         assert str(pytest_wrapped_e.value) == correct_output

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -27,7 +27,7 @@ def test_error_message():
     with mock.patch("sys.argv", ["tldr", "73eb6f19cd6f"]):
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             tldr.main()
-        correct_output = "`73eb6f19cd6f` documentation is not available. If you want to contribute it, feel free to send a pull request to: https://github.com/tldr-pages/tldr." # noqa
+        correct_output = "`73eb6f19cd6f` documentation is not available. If you want to contribute it, feel free to send a pull request to: https://github.com/tldr-pages/tldr" # noqa
         print("Test {}".format(pytest_wrapped_e))
         assert pytest_wrapped_e.type == SystemExit
         assert str(pytest_wrapped_e.value) == correct_output

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -27,7 +27,7 @@ def test_error_message():
     with mock.patch("sys.argv", ["tldr", "73eb6f19cd6f"]):
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             tldr.main()
-        correct_output = "`73eb6f19cd6f` documentation is not available. If you want to contribute it, feel free to send a pull request to: https://www.github.com/tldr-pages/tldr."  # noqa
+        correct_output = "`73eb6f19cd6f` documentation is not available. If you want to contribute it, feel free to send a pull request to: https://github.com/tldr-pages/tldr." # noqa
         print("Test {}".format(pytest_wrapped_e))
         assert pytest_wrapped_e.type == SystemExit
         assert str(pytest_wrapped_e.value) == correct_output

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -27,7 +27,7 @@ def test_error_message():
     with mock.patch("sys.argv", ["tldr", "73eb6f19cd6f"]):
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             tldr.main()
-        correct_output = "`73eb6f19cd6f` documentation is not available. Consider contributing a pull request to https://github.com/tldr-pages/tldr"  # noqa
+        correct_output = "`73eb6f19cd6f` documentation is not available. If you want to contribute it, feel free to send a pull request to: https://www.github.com/tldr-pages/tldr."  # noqa
         print("Test {}".format(pytest_wrapped_e))
         assert pytest_wrapped_e.type == SystemExit
         assert str(pytest_wrapped_e.value) == correct_output

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -27,7 +27,7 @@ def test_error_message():
     with mock.patch("sys.argv", ["tldr", "73eb6f19cd6f"]):
         with pytest.raises(SystemExit) as pytest_wrapped_e:
             tldr.main()
-        correct_output = "`73eb6f19cd6f` documentation is not available. If you want to contribute it, feel free to send a pull request to: https://github.com/tldr-pages/tldr" # noqa
+        correct_output = "`73eb6f19cd6f` documentation is not available.\nIf you want to contribute it, feel free to send a pull request to: https://github.com/tldr-pages/tldr" # noqa
         print("Test {}".format(pytest_wrapped_e))
         assert pytest_wrapped_e.type == SystemExit
         assert str(pytest_wrapped_e.value) == correct_output

--- a/tldr.py
+++ b/tldr.py
@@ -468,7 +468,7 @@ def main():
             if not result:
                 sys.exit((
                     "`{cmd}` documentation is not available. "
-                    "If you want to contribute it, \n feel free to" 
+                    "If you want to contribute it, \n feel free to"
                     " send a pull request to:https://github.com/tldr-pages/tldr"
                 ).format(cmd=command))
             else:

--- a/tldr.py
+++ b/tldr.py
@@ -468,7 +468,7 @@ def main():
             if not result:
                 sys.exit((
                     "`{cmd}` documentation is not available. "
-                    "Consider contributing a pull request to "
+                    "If you want to contribute it, feel free to send a pull request to:"
                     "https://github.com/tldr-pages/tldr"
                 ).format(cmd=command))
             else:

--- a/tldr.py
+++ b/tldr.py
@@ -468,7 +468,7 @@ def main():
             if not result:
                 sys.exit((
                     "`{cmd}` documentation is not available. "
-                    "Consider contributing Pull Request to "
+                    "Consider contributing a pull request to "
                     "https://github.com/tldr-pages/tldr"
                 ).format(cmd=command))
             else:

--- a/tldr.py
+++ b/tldr.py
@@ -468,7 +468,8 @@ def main():
             if not result:
                 sys.exit((
                     "`{cmd}` documentation is not available. "
-                    "If you want to contribute it, feel free to send a pull request to:"
+                    "If you want to contribute it,"
+                    "feel free to send a pull request to:"
                     "https://github.com/tldr-pages/tldr"
                 ).format(cmd=command))
             else:

--- a/tldr.py
+++ b/tldr.py
@@ -468,7 +468,7 @@ def main():
             if not result:
                 sys.exit((
                     "`{cmd}` documentation is not available. "
-                    "If you want to contribute it,"
+                    "If you want to contribute it, "
                     "feel free to send a pull request to:"
                     "https://github.com/tldr-pages/tldr"
                 ).format(cmd=command))

--- a/tldr.py
+++ b/tldr.py
@@ -468,9 +468,8 @@ def main():
             if not result:
                 sys.exit((
                     "`{cmd}` documentation is not available. "
-                    "If you want to contribute it, "
-                    "feel free to send a pull request to:"
-                    "https://github.com/tldr-pages/tldr"
+                    "If you want to contribute it, \n feel free to" 
+                    " send a pull request to:https://github.com/tldr-pages/tldr"
                 ).format(cmd=command))
             else:
                 output(result)

--- a/tldr.py
+++ b/tldr.py
@@ -467,9 +467,9 @@ def main():
             )
             if not result:
                 sys.exit((
-                    "`{cmd}` documentation is not available. "
-                    "If you want to contribute it, \n feel free to"
-                    " send a pull request to:https://github.com/tldr-pages/tldr"
+                    "`{cmd}` documentation is not available.\n"
+                    "If you want to contribute it, feel free to"
+                    " send a pull request to: https://github.com/tldr-pages/tldr"
                 ).format(cmd=command))
             else:
                 output(result)


### PR DESCRIPTION
I am surprised that this issue has gone unnoticed, it must be because we have so pages documented ;) 

Also I don't know whether you agree with the de-capitalization, however I feel this is correct since with using the word `PRs`, you are indicating that they are a part of an acronym 