### PR TITLE
Change TLDR_CACHE_MAX_AGE default

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Cache is downloaded from `TLDR_DOWNLOAD_CACHE_LOCATION` (defaults to the one des
 * `TLDR_CACHE_ENABLED` (default is `1`):
     * If set to `1`, the client will first try to load from cache, and fall back to fetching from the internet if the cache doesn't exist or is too old.
     * If set to `0`, the client will fetch from the internet, and fall back to the cache if the page cannot be fetched from the internet.
-* `TLDR_CACHE_MAX_AGE` (default is `168`): maximum age of the cache in hours to be considered as valid when `TLDR_CACHE_ENABLED` is set to `1`.
+* `TLDR_CACHE_MAX_AGE` (default is `168` hours, which is equivalent to a week): maximum age of the cache in hours to be considered as valid when `TLDR_CACHE_ENABLED` is set to `1`.
 
 #### Cache location
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Cache is downloaded from `TLDR_DOWNLOAD_CACHE_LOCATION` (defaults to the one des
 * `TLDR_CACHE_ENABLED` (default is `1`):
     * If set to `1`, the client will first try to load from cache, and fall back to fetching from the internet if the cache doesn't exist or is too old.
     * If set to `0`, the client will fetch from the internet, and fall back to the cache if the page cannot be fetched from the internet.
-* `TLDR_CACHE_MAX_AGE` (default is `24`): maximum age of the cache in hours to be considered as valid when `TLDR_CACHE_ENABLED` is set to `1`.
+* `TLDR_CACHE_MAX_AGE` (default is `168`): maximum age of the cache in hours to be considered as valid when `TLDR_CACHE_ENABLED` is set to `1`.
 
 #### Cache location
 

--- a/tldr.py
+++ b/tldr.py
@@ -30,9 +30,9 @@ DOWNLOAD_CACHE_LOCATION = os.environ.get(
     'https://tldr-pages.github.io/assets/tldr.zip'
 )
 
-USE_NETWORK = int(os.environ.get('TLDR_NETWORK_ENABLED', '1')) > 0
-USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0
-MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 24))
+USE_NETWORK = int(os.environ.get('TLDR_NETWORK_ENABLED', '1')) > 0 # Defaults to True
+USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0 # Defaults to True
+MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 168)) # Defaults to 168 hours (a week)
 
 URLOPEN_CONTEXT = None
 if int(os.environ.get('TLDR_ALLOW_INSECURE', '0')) == 1:

--- a/tldr.py
+++ b/tldr.py
@@ -30,9 +30,9 @@ DOWNLOAD_CACHE_LOCATION = os.environ.get(
     'https://tldr-pages.github.io/assets/tldr.zip'
 )
 
-USE_NETWORK = int(os.environ.get('TLDR_NETWORK_ENABLED', '1')) > 0 # Defaults to True
-USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0 # Defaults to True
-MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 168)) # Defaults to 168 hours (a week)
+USE_NETWORK = int(os.environ.get('TLDR_NETWORK_ENABLED', '1')) > 0
+USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0
+MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 168))
 
 URLOPEN_CONTEXT = None
 if int(os.environ.get('TLDR_ALLOW_INSECURE', '0')) == 1:

--- a/tldr.py
+++ b/tldr.py
@@ -32,7 +32,7 @@ DOWNLOAD_CACHE_LOCATION = os.environ.get(
 
 USE_NETWORK = int(os.environ.get('TLDR_NETWORK_ENABLED', '1')) > 0
 USE_CACHE = int(os.environ.get('TLDR_CACHE_ENABLED', '1')) > 0
-MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 168))
+MAX_CACHE_AGE = int(os.environ.get('TLDR_CACHE_MAX_AGE', 24*7))
 
 URLOPEN_CONTEXT = None
 if int(os.environ.get('TLDR_ALLOW_INSECURE', '0')) == 1:


### PR DESCRIPTION
I feel 24 hours is extreme, and it annoys me when I first started using this client.

On average I probably only use tldr 1-2 times a day, therefore I have to wait each time for it to download a new cache everyday, which normally includes the additions of 0-10 pages/changes.

It goes from nearly instant with using an _out of date cache_ to waiting a few seconds for a command if you use an __updated cache__ which is just slightly annoying.

Simple change, however others may find this controversial :shrug: 

edit: PS, I forgot to mention that I had already changed the cache date for my .zshrc a weeks back, however the change I made, I felt needed to be standardized 