### PR TITLE
Lowercase command name before resolving page

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -506,7 +506,7 @@ def main() -> None:
                            plain=options.markdown)
     else:
         try:
-            command = '-'.join(options.command)
+            command = '-'.join(options.command).lower()
             result = get_page(
                 command,
                 options.source,


### PR DESCRIPTION
Per the [v1.5 specification](https://github.com/tldr-pages/tldr/releases/tag/v1.5):

> Add requirement for converting command names to lowercase before running the page resolution algorithm.

This PR adds this in.