### PR TITLE
Update testcase for more information link

### DIFF
--- a/tests/data/gem.md
+++ b/tests/data/gem.md
@@ -1,6 +1,7 @@
 # gem
 
 > Interact with the package manager for the Ruby programming language.
+> More information: <https://rubygems.org>.
 
 - Install latest version of a gem
 

--- a/tests/data/gem_rendered
+++ b/tests/data/gem_rendered
@@ -2,6 +2,7 @@
   [1mgem[0m
 
   Interact with the package manager for the Ruby programming language.[0m
+  More information: https://rubygems.org.[0m
 
   [32m- Install latest version of a gem[0m
     [31mgem install [0mgemname[0m[31m[0m


### PR DESCRIPTION
Updates the render test to include the second line with the more information link in description.

Could not reproduce the bug in #175, not sure what might have caused in the first place, but this shows there's no regression within the repo on that.

Closes #175 