### PR TITLE
README: remove ../local/.. from auto-completion setup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,6 @@ If you are experiencing issues with *tldr*, consider deleting the cache files be
 ```bash
 # bash
 tldr --print-completion bash | sudo tee "$BASH_COMPLETION_COMPAT_DIR"/tldr
-# zsh
 # zsh (recommend double checking where zsh/site-functions directory is located)
 ## for macOS:
 tldr --print-completion zsh | sudo tee /usr/local/share/zsh/site-functions/_tldr

--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ If you are experiencing issues with *tldr*, consider deleting the cache files be
 # bash
 tldr --print-completion bash | sudo tee "$BASH_COMPLETION_COMPAT_DIR"/tldr
 # zsh
+# zsh (recommend double checking where zsh/site-functions directory is located)
+## for macOS:
+tldr --print-completion zsh | sudo tee /usr/local/share/zsh/site-functions/_tldr
+## for Linux:
 tldr --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_tldr
 ```
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ If you are experiencing issues with *tldr*, consider deleting the cache files be
 ```bash
 # bash
 tldr --print-completion bash | sudo tee "$BASH_COMPLETION_COMPAT_DIR"/tldr
-# zsh (recommend double checking where zsh/site-functions directory is located)
+# zsh (it is recommended to check where zsh/site-functions directory is located)
 ## for macOS:
 tldr --print-completion zsh | sudo tee /usr/local/share/zsh/site-functions/_tldr
 ## for Linux:

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ If you are experiencing issues with *tldr*, consider deleting the cache files be
 # bash
 tldr --print-completion bash | sudo tee "$BASH_COMPLETION_COMPAT_DIR"/tldr
 # zsh
-tldr --print-completion zsh | sudo tee /usr/local/share/zsh/site-functions/_tldr
+tldr --print-completion zsh | sudo tee /usr/share/zsh/site-functions/_tldr
 ```
 
 See the `shtab` [docs](https://pypi.org/project/shtab/#usage) for other installation methods.


### PR DESCRIPTION
I am unsure whether this is correct however I am assuming that most machines  have the ZSH share folder in /usr/share rather than /usr/local/share