### PR TITLE
improve handling of tokens ending with braces

### DIFF
--- a/tests/data/jq.md
+++ b/tests/data/jq.md
@@ -1,0 +1,37 @@
+# jq
+
+> A command-line JSON processor that uses a domain-specific language.
+> More information: <https://stedolan.github.io/jq>.
+
+- Output a JSON file, in pretty-print format:
+
+`jq . {{file.json}}`
+
+- Output all elements from arrays (or all the values from objects) in a JSON file:
+
+`jq '.[]' {{file.json}}`
+
+- Read JSON objects from a file into an array, and output it (inverse of `jq .[]`):
+
+`jq --slurp . {{file.json}}`
+
+- Output the first element in a JSON file:
+
+`jq '.[0]' {{file.json}}`
+
+- Output the value of a given key of each element in a JSON text from stdin:
+
+`cat {{file.json}} | jq 'map(.{{key_name}})'`
+
+- Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys `key_name` and `other_key_name`):
+
+`cat {{file.json}} | jq '{{{my_new_key}}: .{{key_name}}, {{my_other_key}}: .{{other_key_name}}}'`
+
+- Combine multiple filters:
+
+`cat {{file.json}} | jq 'unique | sort | reverse'`
+
+- Output the value of a given key to a string (and disable JSON output):
+
+`cat {{file.json}} | jq --raw-output '"some text: \(.{{key_name}})"'`
+

--- a/tests/data/jq_rendered
+++ b/tests/data/jq_rendered
@@ -1,0 +1,30 @@
+
+  [1mjq[0m
+
+  A command-line JSON processor that uses a domain-specific language.[0m
+  More information: https://stedolan.github.io/jq.[0m
+
+  [32m- Output a JSON file, in pretty-print format:[0m
+    [31mjq . [0mfile.json[0m[31m[0m
+
+  [32m- Output all elements from arrays (or all the values from objects) in a JSON file:[0m
+    [31mjq '.[]' [0mfile.json[0m[31m[0m
+
+  [32m- Read JSON objects from a file into an array, and output it (inverse of `jq .[]`):[0m
+    [31mjq --slurp . [0mfile.json[0m[31m[0m
+
+  [32m- Output the first element in a JSON file:[0m
+    [31mjq '.[0]' [0mfile.json[0m[31m[0m
+
+  [32m- Output the value of a given key of each element in a JSON text from stdin:[0m
+    [31mcat [0mfile.json[0m[31m | jq 'map(.[0mkey_name[0m[31m)'[0m
+
+  [32m- Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys `key_name` and `other_key_name`):[0m
+    [31mcat [0mfile.json[0m[31m | jq '[0m{my_new_key[0m[31m: .[0mkey_name[0m[31m, [0mmy_other_key[0m[31m: .[0mother_key_name[0m}[31m'[0m
+
+  [32m- Combine multiple filters:[0m
+    [31mcat [0mfile.json[0m[31m | jq 'unique | sort | reverse'[0m
+
+  [32m- Output the value of a given key to a string (and disable JSON output):[0m
+    [31mcat [0mfile.json[0m[31m | jq --raw-output '"some text: \(.[0mkey_name[0m[31m)"'[0m
+

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -6,10 +6,12 @@ import tldr
 import types
 from unittest import mock
 
+page_names = ('gem', 'jq')
 
-def test_whole_page():
-    with open("tests/data/gem.md", "rb") as f_original:
-        with open("tests/data/gem_rendered", "rb") as f_rendered:
+@pytest.mark.parametrize("page_name", page_names)
+def test_whole_page(page_name):
+    with open(f"tests/data/{page_name}.md", "rb") as f_original:
+        with open(f"tests/data/{page_name}_rendered", "rb") as f_rendered:
             old_stdout = sys.stdout
             sys.stdout = io.StringIO()
             sys.stdout.buffer = types.SimpleNamespace()
@@ -24,8 +26,9 @@ def test_whole_page():
             assert tldr_output == correct_output
 
 
-def test_markdown_mode():
-    with open("tests/data/gem.md", "rb") as f_original:
+@pytest.mark.parametrize("page_name", page_names)
+def test_markdown_mode(page_name):
+    with open(f"tests/data/{page_name}.md", "rb") as f_original:
         d_original = f_original.read()
         old_stdout = sys.stdout
         sys.stdout = io.StringIO()

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -6,7 +6,10 @@ import tldr
 import types
 from unittest import mock
 
+# gem is a basic test of page rendering
+# jq is a more complicated test for token parsing
 page_names = ('gem', 'jq')
+
 
 @pytest.mark.parametrize("page_name", page_names)
 def test_whole_page(page_name):

--- a/tldr.py
+++ b/tldr.py
@@ -296,7 +296,7 @@ ACCEPTED_COLOR_ATTRS = [
 
 LEADING_SPACES_NUM = 2
 
-COMMAND_SPLIT_REGEX = re.compile(r'(?P<param>{{.+?}})')
+COMMAND_SPLIT_REGEX = re.compile(r'(?P<param>{{.+?}*}})')
 PARAM_REGEX = re.compile(r'(?:{{)(?P<param>.+?)(?:}})')
 
 


### PR DESCRIPTION
Fixes #184 

Tokens may contain any character, including a `}` at its end. The current parser to detect tokens greedily picks up the sequence `}}`, which does not include any number of trailing `}` which would actually end the token. For example, given `{{{ a }}}`, the parser would detect the token as `{ a`, and leave a trailing `}` on the line, when the actual token is `{ a }`. 

This PR modifies our regex so that we include any number of `}` characters greedily before our final `}}` that closes the token, so that we force the final `}}` as our token closure. This looks like it handles both examples given in #184 as expected, and a quick look did not show any pages as looking abnormal.