### PR TITLE
Specify specification support for v1.5

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -18,7 +18,7 @@ import colorama  # Required for Windows
 import shtab
 
 __version__ = "3.0.0"
-__client_specification__ = "1.4"
+__client_specification__ = "1.5"
 
 REQUEST_HEADERS = {'User-Agent': 'tldr-python-client'}
 PAGES_SOURCE_LOCATION = os.environ.get(


### PR DESCRIPTION
With #176 merged, the client should be v1.5 compatible with the [specification](https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md).