### PR TITLE
Change non-word regex to be POSIX compliant

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -477,10 +477,10 @@ def create_parser() -> ArgumentParser:
 
     shtab.add_argument_to(parser, preamble={
         'bash': r'''shtab_tldr_cmd_list(){{
-          compgen -W "$("{py}" -m tldr --list | sed 's/\W/ /g')" -- "$1"
+          compgen -W "$("{py}" -m tldr --list | sed 's/[^[:alnum:]_]/ /g')" -- "$1"
         }}'''.format(py=sys.executable),
         'zsh': r'''shtab_tldr_cmd_list(){{
-          _describe 'command' "($("{py}" -m tldr --list | sed 's/\W/ /g'))"
+          _describe 'command' "($("{py}" -m tldr --list | sed 's/[^[:alnum:]_]/ /g'))"
         }}'''.format(py=sys.executable)
     })
 


### PR DESCRIPTION
Fixes #194 

This makes the regex compatible with both BSD and GNU versions of sed.