### PR TITLE
Fix color code in non-tty output

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -331,6 +331,9 @@ def colors_of(key: str) -> Tuple[str, str, List[str]]:
 
 
 def output(page: str, plain: bool = False) -> None:
+    if not sys.stdout.isatty():
+        plain = True
+
     if not plain:
         print()
     for line in page:


### PR DESCRIPTION
check if the output is a tty, if not then don't emit shell color codes.

This is from issue https://github.com/p-e-w/shin/issues/3#issue-1423149106