### PR TITLE
ci: pin ubuntu version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   deploy:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on: ['push', 'pull_request']
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       matrix:


### PR DESCRIPTION
The rollover of `ubuntu-latest` to Ubuntu 22.04 in August broke running Python 3.6. While removing that version would fix things, better to not have the choice of OS for the runner be the deciding factor, and also to not have things "randomly", like when `ubuntu-latest` moves to Ubuntu 24.04 and possibly breaks another python version.

Ubuntu 20.04 is supported upstream for the next 10 years, so viable to see GH supporting it for a while yet.