### PR TITLE
Fix forcing color through termcolor

### DIFF
--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -12,7 +12,8 @@ page_names = ('gem', 'jq')
 
 
 @pytest.mark.parametrize("page_name", page_names)
-def test_whole_page(page_name):
+def test_whole_page(page_name, monkeypatch):
+    monkeypatch.setenv("FORCE_COLOR", "1")
     with open(f"tests/data/{page_name}.md", "rb") as f_original:
         with open(f"tests/data/{page_name}_rendered", "rb") as f_rendered:
             old_stdout = sys.stdout

--- a/tldr.py
+++ b/tldr.py
@@ -493,6 +493,8 @@ def main() -> None:
     options = parser.parse_args()
 
     colorama.init(strip=options.color)
+    if options.color == False:
+        os.environ["FORCE_COLOR"] = "true"
 
     if options.update_cache:
         update_cache(language=options.language)

--- a/tldr.py
+++ b/tldr.py
@@ -493,7 +493,7 @@ def main() -> None:
     options = parser.parse_args()
 
     colorama.init(strip=options.color)
-    if options.color == False:
+    if options.color is False:
         os.environ["FORCE_COLOR"] = "true"
 
     if options.update_cache:


### PR DESCRIPTION
This PR fixes a bug introduced by termcolor 2.1.0, where that library will now detect whether or not the process is running a TTY and disable outputting color if so. This broke using the `--color` argument to force color when piping to another process (e.g. `less`), as well as our pytest function for checking rendered output.

The fix is ensuring that we set the environment variable `FORCE_COLOR` in the cases where we want color, and might not have a TTY (e.g. in the pytest, or when using `--color` option).