### PR TITLE
Update versions for GH actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,9 +13,10 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: '3.7'
 
@@ -56,7 +57,7 @@ jobs:
         .
 
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@master
+      uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,10 +11,10 @@ jobs:
         python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', 'pypy3.9']
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
PR updates the versions for the various third-party actions we use in GH workflows. For `pypa/gh-action-pypi-publish`, they've deprecated using `master` for the version reference and now recommend using `release/v1`, per [their docs](https://github.com/pypa/gh-action-pypi-publish/tree/c7f29f7adef1a245bd91520e94867e5c6eedddcc#-master-branch-sunset-).