### PR TITLE
chore: bump version to 3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 3.2.0 (03/05/2023)
+
+### Bugfiles
+
+* Fix forcing color through termcolor
+* Change non-word regex to be POSIX compliant
+* Update page source to use main branch
+
 ## 3.1.0 (02/16/2022)
 
 ### Features

--- a/tldr.py
+++ b/tldr.py
@@ -17,7 +17,7 @@ from termcolor import colored
 import colorama  # Required for Windows
 import shtab
 
-__version__ = "3.1.0"
+__version__ = "3.2.0"
 __client_specification__ = "1.5"
 
 REQUEST_HEADERS = {'User-Agent': 'tldr-python-client'}


### PR DESCRIPTION
This PR bumps the version to `3.2.0`, once merged I will tag and create a new release.