### PR TITLE
fix: return `str` instead of `list` when executing `tldr -l`

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -504,7 +504,7 @@ def main() -> None:
         parser.print_help(sys.stderr)
         sys.exit(1)
     if options.list:
-        print(get_commands(options.platform))
+        print('\n'.join(get_commands(options.platform)))
     elif options.render:
         for command in options.command:
             if os.path.exists(command):

--- a/tldr.py
+++ b/tldr.py
@@ -301,7 +301,7 @@ COMMAND_SPLIT_REGEX = re.compile(r'(?P<param>{{.+?}*}})')
 PARAM_REGEX = re.compile(r'(?:{{)(?P<param>.+?)(?:}})')
 
 
-def get_commands(platforms: Optional[List[str]] = None) -> List[str]:
+def get_commands(platforms: Optional[List[str]] = None) -> str:
     if platforms is None:
         platforms = get_platform_list()
 
@@ -312,7 +312,7 @@ def get_commands(platforms: Optional[List[str]] = None) -> List[str]:
             if not os.path.exists(path):
                 continue
             commands += [file[:-3] for file in os.listdir(path) if file.endswith(".md")]
-    return commands
+    return '\n'.join(commands)
 
 
 def colors_of(key: str) -> Tuple[str, str, List[str]]:

--- a/tldr.py
+++ b/tldr.py
@@ -301,7 +301,7 @@ COMMAND_SPLIT_REGEX = re.compile(r'(?P<param>{{.+?}*}})')
 PARAM_REGEX = re.compile(r'(?:{{)(?P<param>.+?)(?:}})')
 
 
-def get_commands(platforms: Optional[List[str]] = None) -> str:
+def get_commands(platforms: Optional[List[str]] = None) -> List[str]:
     if platforms is None:
         platforms = get_platform_list()
 
@@ -312,7 +312,7 @@ def get_commands(platforms: Optional[List[str]] = None) -> str:
             if not os.path.exists(path):
                 continue
             commands += [file[:-3] for file in os.listdir(path) if file.endswith(".md")]
-    return '\n'.join(commands)
+    return commands
 
 
 def colors_of(key: str) -> Tuple[str, str, List[str]]:


### PR DESCRIPTION
Return `str` separated by `\n`.

It helps when using by other programs, like `fzf`
I've `alias`:
`alias ch="tldr \$(tldr -l | fzf)"`
so it'll search through all pages.

![focused_window_2023-10-29_09-24-04_900x450](https://github.com/tldr-pages/tldr-python-client/assets/6236057/f72c4bd4-8c3e-47e6-a1f1-b16c040196e7)

Closes #221.