### PR TITLE
docs: add Repology badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Python command-line client for [tldr pages](https://github.com/tldr-pages/tldr).
 
 ## Installation
 
+[![Packaging status](https://repology.org/badge/vertical-allrepos/tldr-python-client.svg)](https://repology.org/project/python-tldr-client/versions)
+
 ### from PyPI
 
 ```bash


### PR DESCRIPTION
This PR adds a vertical badge that shows all repos that contain this package along with their versions. There is also a smaller badge:
[![Packaging status](https://repology.org/badge/tiny-repos/tldr-python-client.svg)](https://repology.org/project/tldr-python-client/versions)