### PR TITLE
feat: add `--update` to match client spec

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -428,7 +428,7 @@ def create_parser() -> ArgumentParser:
                         type=str,
                         help="Search for a specific command from a query")
 
-    parser.add_argument('-u', '--update_cache',
+    parser.add_argument('-u', '--update', '--update_cache',
                         action='store_true',
                         help="Update the local cache of pages and exit")
 
@@ -500,7 +500,7 @@ def main() -> None:
     if options.color is False:
         os.environ["FORCE_COLOR"] = "true"
 
-    if options.update_cache:
+    if options.update:
         update_cache(language=options.language)
         return
     elif len(sys.argv) == 1:


### PR DESCRIPTION
Add support for `--update` to match the client specification. This keeps support for `--update_cache` for backwards compatibility.

https://github.com/tldr-pages/tldr/blob/main/CLIENT-SPECIFICATION.md#arguments