### PR TITLE
Respect language settings when geting a list of commands

### DIFF
--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -135,3 +135,24 @@ def test_get_cache_dir_default(monkeypatch):
     monkeypatch.delenv("HOME", raising=False)
     monkeypatch.setattr(Path, 'home', lambda: Path('/tmp/expanduser'))
     assert tldr.get_cache_dir() == Path("/tmp/expanduser/.cache/tldr")
+
+
+def test_get_commands(monkeypatch, tmp_path):
+    cache_default = tmp_path / ".cache" / "tldr" / "pages" / "linux"
+    Path.mkdir(cache_default, parents=True)
+    Path.touch(cache_default / "lspci.md")
+
+    monkeypatch.setenv("HOME", tmp_path)
+
+    result = tldr.get_commands(platforms=["linux"])
+
+    assert isinstance(result, list)
+    assert "lspci (en)" in result
+
+    cache_zh = tmp_path / ".cache" / "tldr" / "pages.zh" / "linux"
+    Path.mkdir(cache_zh, parents=True)
+    Path.touch(cache_zh / "lspci.md")
+
+    result = tldr.get_commands(platforms=["linux"], language=["zh_CN"])
+
+    assert "lspci (zh)" in result

--- a/tldr.py
+++ b/tldr.py
@@ -305,17 +305,27 @@ COMMAND_SPLIT_REGEX = re.compile(r'(?P<param>{{.+?}*}})')
 PARAM_REGEX = re.compile(r'(?:{{)(?P<param>.+?)(?:}})')
 
 
-def get_commands(platforms: Optional[List[str]] = None) -> List[str]:
+def get_commands(platforms: Optional[List[str]] = None,
+                 language: Optional[str] = None) -> List[str]:
     if platforms is None:
         platforms = get_platform_list()
+
+    if language:
+        languages = [get_language_code(language[0])]
+    else:
+        languages = get_language_list()
 
     commands = []
     if get_cache_dir().exists():
         for platform in platforms:
-            path = get_cache_dir() / 'pages' / platform
-            if not path.exists():
-                continue
-            commands += [file.stem for file in path.iterdir() if file.suffix == '.md']
+            for language in languages:
+                pages_dir = f'pages.{language}' if language != 'en' else 'pages'
+                path = get_cache_dir() / pages_dir / platform
+                if not path.exists():
+                    continue
+                commands += [f"{file.stem} ({language})"
+                             for file in path.iterdir()
+                             if file.suffix == '.md']
     return commands
 
 
@@ -511,7 +521,7 @@ def main() -> None:
         parser.print_help(sys.stderr)
         sys.exit(1)
     if options.list:
-        print('\n'.join(get_commands(options.platform)))
+        print('\n'.join(get_commands(options.platform, options.language)))
     elif options.render:
         for command in options.command:
             if Path(command).exists():


### PR DESCRIPTION
Fixes: https://github.com/tldr-pages/tldr-python-client/issues/238

If you agree with this approach, I can add tests for that.