### PR TITLE
fix: update assets URL and create directories recursively

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -28,7 +28,7 @@ PAGES_SOURCE_LOCATION = os.environ.get(
 ).rstrip('/')
 DOWNLOAD_CACHE_LOCATION = os.environ.get(
     'TLDR_DOWNLOAD_CACHE_LOCATION',
-    'https://tldr-pages.github.io/assets/tldr.zip'
+    'https://tldr.sh/assets/tldr.zip'
 )
 
 USE_NETWORK = int(os.environ.get('TLDR_NETWORK_ENABLED', '1')) > 0
@@ -115,7 +115,7 @@ def store_page_to_cache(
 ) -> Optional[str]:
     try:
         cache_file_path = get_cache_file_path(command, platform, language)
-        cache_file_path.parent.mkdir(exist_ok=True)
+        cache_file_path.parent.mkdir(parents=True, exist_ok=True)
         with cache_file_path.open("wb") as cache_file:
             cache_file.write(page)
     except Exception:

--- a/tldr.py
+++ b/tldr.py
@@ -28,7 +28,7 @@ PAGES_SOURCE_LOCATION = os.environ.get(
 ).rstrip('/')
 DOWNLOAD_CACHE_LOCATION = os.environ.get(
     'TLDR_DOWNLOAD_CACHE_LOCATION',
-    'https://tldr.sh/assets/tldr.zip'
+    'https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip'
 )
 
 USE_NETWORK = int(os.environ.get('TLDR_NETWORK_ENABLED', '1')) > 0


### PR DESCRIPTION
- Update DOWNLOAD_CACHE_LOCATION location to tldr.sh
- Fixed a regression caused by pathlib refactoring, `path.mkdir` needs `parents=True` to create the directories recursively