### PR TITLE
fix/snap: specify platforms to build for and drop i386

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -7,6 +7,23 @@ description: Python command-line client for tldr pages.
 grade: stable
 confinement: strict
 
+platforms:
+  amd64:
+    build-on: [amd64]
+    build-for: [amd64]
+  arm64:
+    build-on: [arm64]
+    build-for: [arm64]
+  armhf:
+    build-on: [armhf]
+    build-for: [armhf]
+  ppc64el:
+    build-on: [ppc64el]
+    build-for: [ppc64el]
+  s390x:
+    build-on: [s390x]
+    build-for: [s390x]
+
 parts:
   tldr:
     plugin: python


### PR DESCRIPTION
This PR adds specifications for the platforms to be built in the Snapcraft config file. 

I have dropped the `i386` platform as it is no longer supported since `core20` (we currently use `core24` which is based on Ubuntu 24.04 LTS). And we never made a stable/beta release for it (only edge releases were made by their build system automatically).

## References

- https://snapcraft.io/docs/migrating-bases#heading--arch
- https://snapcraft.io/docs/reference-architectures

![image](https://github.com/tldr-pages/tldr-python-client/assets/26346867/b255153b-7ce9-413a-8fc1-01bf0cfb9716)
