### PR TITLE
feat: stylize text inside backticks when appearing in example description

### DIFF
--- a/tests/data/jq_rendered
+++ b/tests/data/jq_rendered
@@ -10,7 +10,7 @@
   [32m- Output all elements from arrays (or all the values from objects) in a JSON file:[0m
     [31mjq '.[]' [0mfile.json[0m[31m[0m
 
-  [32m- Read JSON objects from a file into an array, and output it (inverse of [3mjq .[][0m):[0m
+  [32m- Read JSON objects from a file into an array, and output it (inverse of [0m[3m[33mjq .[][0m[23m[32m):[0m
     [31mjq --slurp . [0mfile.json[0m[31m[0m
 
   [32m- Output the first element in a JSON file:[0m
@@ -19,7 +19,7 @@
   [32m- Output the value of a given key of each element in a JSON text from stdin:[0m
     [31mcat [0mfile.json[0m[31m | jq 'map(.[0mkey_name[0m[31m)'[0m
 
-  [32m- Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys [3mkey_name[0m and [3mother_key_name[0m):[0m
+  [32m- Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys [0m[3m[33mkey_name[0m[23m[32m and [0m[3m[33mother_key_name[0m[23m[32m):[0m
     [31mcat [0mfile.json[0m[31m | jq '[0m{my_new_key[0m[31m: .[0mkey_name[0m[31m, [0mmy_other_key[0m[31m: .[0mother_key_name[0m}[31m'[0m
 
   [32m- Combine multiple filters:[0m

--- a/tests/data/jq_rendered
+++ b/tests/data/jq_rendered
@@ -10,7 +10,7 @@
   [32m- Output all elements from arrays (or all the values from objects) in a JSON file:[0m
     [31mjq '.[]' [0mfile.json[0m[31m[0m
 
-  [32m- Read JSON objects from a file into an array, and output it (inverse of `jq .[]`):[0m
+  [32m- Read JSON objects from a file into an array, and output it (inverse of [3mjq .[][0m):[0m
     [31mjq --slurp . [0mfile.json[0m[31m[0m
 
   [32m- Output the first element in a JSON file:[0m
@@ -19,7 +19,7 @@
   [32m- Output the value of a given key of each element in a JSON text from stdin:[0m
     [31mcat [0mfile.json[0m[31m | jq 'map(.[0mkey_name[0m[31m)'[0m
 
-  [32m- Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys `key_name` and `other_key_name`):[0m
+  [32m- Output the value of multiple keys as a new JSON object (assuming the input JSON has the keys [3mkey_name[0m and [3mother_key_name[0m):[0m
     [31mcat [0mfile.json[0m[31m | jq '[0m{my_new_key[0m[31m: .[0mkey_name[0m[31m, [0mmy_other_key[0m[31m: .[0mother_key_name[0m}[31m'[0m
 
   [32m- Combine multiple filters:[0m

--- a/tldr.py
+++ b/tldr.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
 
+import itertools
 import sys
 import os
 import re
@@ -422,12 +423,17 @@ def output(page: str, plain: bool = False) -> None:
         if plain:
             print(line)
             continue
+
         elif len(line) == 0:
             continue
+
+        # Handle the command name
         elif line[0] == '#':
             line = ' ' * LEADING_SPACES_NUM + \
                 colored(line.replace('# ', ''), *colors_of('name')) + '\n'
             sys.stdout.buffer.write(line.encode('utf-8'))
+
+        # Handle the command description
         elif line[0] == '>':
             line = ' ' * (LEADING_SPACES_NUM - 1) + \
                 colored(
@@ -435,10 +441,22 @@ def output(page: str, plain: bool = False) -> None:
                     *colors_of('description')
                 )
             sys.stdout.buffer.write(line.encode('utf-8'))
+
+        # Handle an example description
         elif line[0] == '-':
             line = '\n' + ' ' * LEADING_SPACES_NUM + \
                 colored(line, *colors_of('example'))
+            # Stylize text within backticks using italics
+            if '`' in line:
+                # Backticks should occur in pairs, so str.split results in an odd number of elements
+                *parts, last_part = line.split('`')
+                # Setup an infinite cycle of italic and reset ANSI escape pairs
+                italics_escapes = itertools.cycle(('\x1B[3m', '\x1B[0m'))
+                # Rejoin the original string parts with the matching escape pairs
+                line = "".join(itertools.chain.from_iterable(zip(parts, italics_escapes))) + last_part
             sys.stdout.buffer.write(line.encode('utf-8'))
+
+        # Handle an example command
         elif line[0] == '`':
             line = line[1:-1]  # Remove backticks for parsing
 

--- a/tldr.py
+++ b/tldr.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 # PYTHON_ARGCOMPLETE_OK
 
-import itertools
 import sys
 import os
 import re


### PR DESCRIPTION
Closes #253 

Hoping I've understood the brief correctly :)

This change will check for the presence of backticks (`) and replace them with the ANSI escape characters for italics (and a matching reset to close the pairs).

This appears to match the desired output from the Rust CLI from the issue.

Example output:
![screenshot_from_2024_10_02_16_50_05](https://github.com/user-attachments/assets/47fe97a0-7acb-497f-904b-9ba142c37b2e)
