### PR TITLE
fix: pytest usage in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,7 +47,7 @@ jobs:
       run: python3 -m flake8
 
     - name: Run test suite
-      run: python3 setup.py pytest
+      run: python3 -m pytest tests/
 
     - name: Test tldr cli
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
 
     - name: Install sphinx dependencies
       run: >-
-        python -m
+        python3 -m
         pip install
         sphinx
         sphinx-argparse
@@ -33,7 +33,7 @@ jobs:
 
     - name: Install tldr dependencies
       run: >-
-        python -m
+        python3 -m
         pip install
         -r
         requirements.txt

--- a/tests/test_tldr.py
+++ b/tests/test_tldr.py
@@ -142,7 +142,7 @@ def test_get_commands(monkeypatch, tmp_path):
     Path.mkdir(cache_default, parents=True)
     Path.touch(cache_default / "lspci.md")
 
-    monkeypatch.setenv("HOME", tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
 
     result = tldr.get_commands(platforms=["linux"])
 


### PR DESCRIPTION
Fixes #255

This should fix the error by not invoking the tests via setup.py, instead using `pytest` directly as per their docs.

I've also made two small cleanups while in the area:

1. Use the command `python3` instead of `python` for consistency within the rest of the `test.yml` file.
2. Fix a pytest warning within the `test_get_commands` test (see screenshots for before/after).

Before:
![screenshot_from_2024_10_03_10_01_16](https://github.com/user-attachments/assets/a10ee795-71a4-4c99-a4c0-6ef5975c4845)

After:
![screenshot_from_2024_10_03_10_01_38](https://github.com/user-attachments/assets/af923600-3386-407e-bf67-0e6dd17b38c9)

This should be enough to get the GHA builds green again on `main` ✅ 
