### PR TITLE
Only require colorama on Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 termcolor
-colorama
+colorama; sys_platform=='win32'
 shtab>=1.3.10

--- a/tldr.py
+++ b/tldr.py
@@ -15,7 +15,6 @@ from urllib.parse import quote
 from urllib.request import urlopen, Request
 from urllib.error import HTTPError, URLError
 from termcolor import colored
-import colorama  # Required for Windows
 import shtab
 
 __version__ = "3.3.0"
@@ -624,7 +623,9 @@ def main() -> None:
 
     options = parser.parse_args()
 
-    colorama.init(strip=options.color)
+    if sys.platform == "win32":
+        import colorama
+        colorama.init(strip=options.color)
     if options.color is False:
         os.environ["FORCE_COLOR"] = "true"
 

--- a/tldr.py
+++ b/tldr.py
@@ -657,7 +657,6 @@ def main() -> None:
         display_option_length = "long"
     if options.short_options and options.long_options:
         display_option_length = "both"
-    
     if sys.platform == "win32":
         import colorama
         colorama.init(strip=options.color)


### PR DESCRIPTION
This removes the `colorama` dependency and import overhead on non-Windows platforms.