### PR TITLE
README: fix location of `tldr.zip`

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ export TLDR_LANGUAGE="es"
 export TLDR_CACHE_ENABLED=1
 export TLDR_CACHE_MAX_AGE=720
 export TLDR_PAGES_SOURCE_LOCATION="https://raw.githubusercontent.com/tldr-pages/tldr/main/pages"
-export TLDR_DOWNLOAD_CACHE_LOCATION="https://tldr-pages.github.io/assets/tldr.zip"
+export TLDR_DOWNLOAD_CACHE_LOCATION="https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip"
 ```
 
 ### Cache


### PR DESCRIPTION
The script itself [is already using GitHub releases](https://github.com/tldr-pages/tldr-python-client/blob/cb63ef4c54499df788f478fea3f5fd304f846055/tldr.py#L31), but the readme hasn't been updated.