### PR TITLE
feat/ci: use commit hash for actions, add arm64 support to test workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,4 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,10 +12,10 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: '3.8'
 
@@ -56,7 +56,7 @@ jobs:
         .
 
     - name: Publish package
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4
       with:
         user: __token__
         password: ${{ secrets.PYPI_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,17 +4,17 @@ on: ['push', 'pull_request']
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ['ubuntu-latest', 'ubuntu-24.04-arm']
 
     strategy:
       matrix:
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
         python-version: ${{ matrix.python-version }}
 
@@ -59,11 +59,12 @@ jobs:
 
     steps:
      - uses: actions/checkout@v4
-     - uses: snapcore/action-build@v1
+     - uses: canonical/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
        id: snapcraft-build
        with:
          snapcraft-args: "-v"
-     - uses: actions/upload-artifact@v4
+
+     - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
        with:
          name: ${{ steps.snapcraft-build.outputs.snap }}
          path: ${{ steps.snapcraft-build.outputs.snap }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,6 +57,7 @@ jobs:
 
   build-snap:
     runs-on: ${{ matrix.os }}
+    needs: ['build']
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -56,10 +56,15 @@ jobs:
         tldr --version
 
   build-snap:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
 
     steps:
      - uses: actions/checkout@v4
+
      - uses: canonical/action-build@3bdaa03e1ba6bf59a65f84a751d943d549a54e79 # v1.3.0
        id: snapcraft-build
        with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,11 @@ on: ['push', 'pull_request']
 
 jobs:
   build:
-    runs-on: ['ubuntu-latest', 'ubuntu-24.04-arm']
+    runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
 
     steps:


### PR DESCRIPTION
## Changes

- This PR switches all version based rewritable action tags to use commit hashes instead.
- Dependabot frequency for GitHub action update check has been changed to “weekly” to incorporate point releases quickly (since we are using hash based approach from now).
- Add GitHub's free partner arm runner (currently in public preview) to build job in test workflow to test the code changes in arm64 too along with amd64.
- I have renamed `snapcore/action-build` to `canonical/action-build` since the latter one is the base repo and snapcore one is a fork.

