### PR TITLE
feat: extend testing CI, drop Python 3.8 *& PyPy 3.9, separate build and publish jobs in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
       with:
-        python-version: '3.8'
+        python-version: '3.9'
 
     - name: Install sphinx toolset
       run: >-

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,19 +6,15 @@ name: Upload Python Package
 
 on:
   release:
-    types: [created]
+    types: [published]
 
 jobs:
-  pypi-publish:
+  release-build:
     runs-on: ubuntu-latest
-
-    environment: 
-      name: pypi
-      url: https://pypi.org/project/tldr/
-
     permissions:
       contents: read
-      id-token: write # Required for accessing OpenID Connect (OIDC) token for PyPI trusted publisher
+      attestations: write # to upload assets attestation of 'dists' for build provenance
+      id-token: write # grant additional permission to attestation action to mint the OIDC token permission
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -29,40 +25,57 @@ jobs:
         python-version: '3.9'
 
     - name: Install sphinx toolset
-      run: >-
-        python -m
-        pip install
-        sphinx
-        sphinx-argparse
-        --user
+      run:
+        python -m pip install sphinx sphinx-argparse --user
 
     - name: Install tldr dependencies
-      run: >-
-        python -m
-        pip install
-        -r
-        requirements.txt
-        --user
+      run:
+        python -m pip install -r requirements.txt --user
 
     - name: Generate the manpage
       working-directory: docs
       run: make man
 
     - name: Install pep517
-      run: >-
-        python -m
-        pip install
-        pep517
-        --user
+      run:
+        python -m pip install pep517 --user
 
     - name: Build a binary wheel and a source tarball
       run: >-
-        python -m
-        pep517.build
+        python -m pep517.build
         --source
         --binary
         --out-dir dist/
         .
+
+    - name: Attest generated files
+      uses: actions/attest-build-provenance@c074443f1aee8d4aeeae555aebba3282517141b2 # v2.2.3
+      with:
+        subject-path: dist/
+
+    - name: Upload release distributions
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      with:
+        name: release-dists
+        path: dist/
+
+  pypi-publish:
+    runs-on: ubuntu-latest
+    needs: ['release-build']
+    
+    environment: 
+      name: pypi
+      url: https://pypi.org/project/tldr/
+    
+    permissions:
+      id-token: write # Required for accessing OpenID Connect (OIDC) token for PyPI trusted publisher
+    
+    steps:
+    - name: Retrieve release distributions
+      uses: actions/download-artifact@95815c38cf2ff2164869cbab79da8d1f422bc89e # v4.2.1
+      with:
+        name: release-dists
+        path: dist/
 
     - name: Publish package
       uses: pypa/gh-action-pypi-publish@76f52bc884231f62b9a034ebfe128415bbaabdfc # v1.12.4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'ubuntu-24.04-arm']
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10', 'pypy3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.10', 'pypy3.11']
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -46,14 +46,14 @@ jobs:
       run: |
         python3 -m pip install .
         tldr --version
-        tldr tldr
+        tldr tldr --markdown
 
   build-macos:
     runs-on: macos-latest
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10', 'pypy3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13', 'pypy3.10', 'pypy3.11']
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -91,14 +91,14 @@ jobs:
       run: |
         python3 -m pip install .
         tldr --version
-        tldr tldr
+        tldr tldr --markdown
 
   build-windows:
     runs-on: windows-latest
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10', 'pypy3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -135,7 +135,7 @@ jobs:
       run: |
         python3 -m pip install .
         tldr --version
-        tldr tldr
+        tldr tldr --markdown
 
   build-snap:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         os: ['ubuntu-latest', 'ubuntu-24.04-arm']
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10', 'pypy3.11']
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -25,20 +25,12 @@ jobs:
         python3 -m pip install -U pytest pytest-runner flake8
 
     - name: Install sphinx dependencies
-      run: >-
-        python3 -m
-        pip install
-        sphinx
-        sphinx-argparse
-        --user
+      run:
+        python3 -m pip install sphinx sphinx-argparse --user
 
     - name: Install tldr dependencies
-      run: >-
-        python3 -m
-        pip install
-        -r
-        requirements.txt
-        --user
+      run:
+        python3 -m pip install -r requirements.txt --user
 
     - name: Generate the manpage
       working-directory: docs
@@ -61,7 +53,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10', 'pypy3.11']
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -82,12 +74,8 @@ jobs:
         echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Install tldr dependencies
-      run: >-
-        python3 -m
-        pip install
-        -r
-        requirements.txt
-        --user
+      run:
+        python3 -m pip install -r requirements.txt --user
 
     - name: Generate the manpage
       working-directory: docs
@@ -110,7 +98,7 @@ jobs:
 
     strategy:
       matrix:
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.10', 'pypy3.11']
 
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -126,20 +114,13 @@ jobs:
         python3 -m pip install -U pytest pytest-runner flake8
 
     - name: Install sphinx dependencies
-      run: >-
-        python -m
-        pip install
-        sphinx
-        sphinx-argparse
-        --user
+      run: |
+         python -m pip install sphinx sphinx-argparse --user
+         echo "$env:USERPROFILE\.local\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Install tldr dependencies
-      run: >-
-        python3 -m
-        pip install
-        -r
-        requirements.txt
-        --user
+      run:
+        python3 -m pip install -r requirements.txt --user
 
     - name: Generate the manpage
       working-directory: docs

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm', 'windows-latest', 'macos-latest']
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -116,7 +116,6 @@ jobs:
     - name: Install sphinx dependencies
       run: |
          python -m pip install sphinx sphinx-argparse --user
-         echo "$env:USERPROFILE\.local\Scripts" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
     - name: Install tldr dependencies
       run:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,12 +3,12 @@ name: Test
 on: ['push', 'pull_request']
 
 jobs:
-  build:
+  build-linux:
     runs-on: ${{ matrix.os }}
 
     strategy:
       matrix:
-        os: ['ubuntu-latest', 'ubuntu-24.04-arm', 'windows-latest', 'macos-latest']
+        os: ['ubuntu-latest', 'ubuntu-24.04-arm']
         python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
 
     steps:
@@ -55,9 +55,108 @@ jobs:
         python3 -m pip install .
         tldr --version
 
+  build-macos:
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install developer dependencies
+      run: |
+        python3 -m pip install -U pip setuptools
+        python3 -m pip install -U pytest pytest-runner flake8
+
+    - name: Install sphinx dependencies
+      run: |
+        brew install sphinx-doc
+        brew link sphinx-doc --force
+
+    - name: Install tldr dependencies
+      run: >-
+        python3 -m
+        pip install
+        -r
+        requirements.txt
+        --user
+
+    - name: Generate the manpage
+      working-directory: docs
+      run: make man
+
+    - name: Lint codebase
+      run: python3 -m flake8
+
+    - name: Run test suite
+      run: python3 -m pytest tests/
+
+    - name: Test tldr cli
+      run: |
+        python3 -m pip install .
+        tldr --version
+
+  build-windows:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12', 'pypy3.9', 'pypy3.10']
+
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@8d9ed9ac5c53483de85588cdf95a591a75ab9f55 # v5.5.0
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install developer dependencies
+      run: |
+        python3 -m pip install -U pip setuptools
+        python3 -m pip install -U pytest pytest-runner flake8
+
+    - name: Install sphinx dependencies
+      run: >-
+        python -m
+        pip install
+        sphinx
+        sphinx-argparse
+        --user
+
+    - name: Install tldr dependencies
+      run: >-
+        python3 -m
+        pip install
+        -r
+        requirements.txt
+        --user
+
+    - name: Generate the manpage
+      working-directory: docs
+      run: make man
+
+    - name: Lint codebase
+      run: python3 -m flake8
+
+    - name: Run test suite
+      run: python3 -m pytest tests/
+
+    - name: Test tldr cli
+      run: |
+        python3 -m pip install .
+        tldr --version
+
   build-snap:
     runs-on: ${{ matrix.os }}
-    needs: ['build']
+    needs: ['build-linux']
 
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,6 +54,7 @@ jobs:
       run: |
         python3 -m pip install .
         tldr --version
+        tldr tldr
 
   build-macos:
     runs-on: macos-latest
@@ -77,8 +78,8 @@ jobs:
 
     - name: Install sphinx dependencies
       run: |
-        brew install sphinx-doc
-        brew link sphinx-doc --force
+        python3 -m pip install sphinx sphinx-argparse
+        echo "$HOME/.local/bin" >> $GITHUB_PATH
 
     - name: Install tldr dependencies
       run: >-
@@ -102,6 +103,7 @@ jobs:
       run: |
         python3 -m pip install .
         tldr --version
+        tldr tldr
 
   build-windows:
     runs-on: windows-latest
@@ -153,6 +155,7 @@ jobs:
       run: |
         python3 -m pip install .
         tldr --version
+        tldr tldr
 
   build-snap:
     runs-on: ${{ matrix.os }}

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         'pytest-runner',
     ],
     version=version,
-    python_requires='~=3.8',
+    python_requires='~=3.9',
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
## Changes

- Renamed existing build workflow to `build-linux` and linked it to `build-snap` step.
- Dropped support for [EoL Python version 3.8](https://devguide.python.org/versions/).
- Dropped support for PyPy 3.9 in workflows and other files.
- Added support for new Python version 3.13 and PyPy version 3.11.


- Added testing builds for Python releases in Windows and MacOS.
  - In MacOS, there is a path issue with Sphinx so after installing it with pip, I am manually adding it to path with `echo "$HOME/.local/bin" >> $GITHUB_PATH`
  - In Windows, there is an issue with PyPy builds (which is unreliable) so I am skipping testing builds for it alone.

- In publish workflow, separated build (included attestation support for dists) and publish steps as suggested in https://docs.github.com/en/actions/use-cases-and-examples/building-and-testing/building-and-testing-python#publishing-to-pypi for better security.