### PR TITLE
cleanup/ci: remove setuptools from developer deps in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
 
     - name: Install developer dependencies
       run: |
-        python3 -m pip install -U pip setuptools
+        python3 -m pip install -U pip
         python3 -m pip install -U pytest pytest-runner flake8
 
     - name: Install sphinx dependencies
@@ -65,7 +65,7 @@ jobs:
 
     - name: Install developer dependencies
       run: |
-        python3 -m pip install -U pip setuptools
+        python3 -m pip install -U pip
         python3 -m pip install -U pytest pytest-runner flake8
 
     - name: Install sphinx dependencies
@@ -110,7 +110,7 @@ jobs:
 
     - name: Install developer dependencies
       run: |
-        python3 -m pip install -U pip setuptools
+        python3 -m pip install -U pip
         python3 -m pip install -U pytest pytest-runner flake8
 
     - name: Install sphinx dependencies


### PR DESCRIPTION
Removing unused developer dependency setuptools since we no longer use it in the backend and instead use Hatch instead.