### PR TITLE
fix: manpage path in pyproject configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,7 +76,7 @@ path = "tldr.py"
 attr = "__version__"
 
 [tool.hatch.build.targets.wheel.shared-data]
-"docs/man" = "share/man/man1"
+"docs/man/tldr.1" = "share/man/man1/tldr.1"
 
 [tool.hatch.build.targets.sdist]
 include = [


### PR DESCRIPTION
This PR fixes the man page path in `pyproject.toml` file that led to `.doctrees` files being included in the final installation of the wheel.

![image](https://github.com/user-attachments/assets/0b3f1cc1-7d25-4acb-b95e-65f82b182c04)

Closes #276