### PR TITLE
cleanup: update workflows, bump snap version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-# This workflow will upload a Python Package using Trusted Publishers automatically when a release is created
+# This workflow will upload a Python Package using Trusted Publishers automatically when a release is created and the deployment is approved by an admin
 # For more information see: https://help.github.com/en/actions/language-and-framework-guides/using-python-with-github-actions#publishing-to-package-registries
 # and https://docs.pypi.org/trusted-publishers/using-a-publisher/.
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -97,7 +97,6 @@ jobs:
       run: |
         python3 -m pip install .
         tldr --version
-        tldr tldr --markdown
 
   build-windows:
     runs-on: windows-latest
@@ -144,7 +143,6 @@ jobs:
       run: |
         python3 -m pip install .
         tldr --version
-        tldr tldr --markdown
 
   build-windows-arm:
       runs-on: windows-11-arm
@@ -183,11 +181,10 @@ jobs:
         run: |
           python3 -m pip install .
           tldr --version
-          tldr tldr --markdown
 
   build-snap:
     runs-on: ${{ matrix.os }}
-    if: github.repository == 'tldr-pages/tldr-python-client' && github.ref == 'refs/heads/main'
+    if: github.repository == 'tldr-pages/tldr-python-client' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
     needs: ['build-linux']
 
     permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,10 +49,10 @@ jobs:
       run: |
         python3 -m pip install .
         tldr --version
-        tldr tldr --markdown
 
   build-macos:
     runs-on: macos-latest
+    needs: ['build-linux']
 
     permissions:
       contents: read
@@ -100,6 +100,7 @@ jobs:
 
   build-windows:
     runs-on: windows-latest
+    needs: ['build-macos']
 
     permissions:
       contents: read
@@ -146,6 +147,7 @@ jobs:
 
   build-windows-arm:
       runs-on: windows-11-arm
+      needs: ['build-windows']
 
       permissions:
         contents: read

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 name: tldr
 base: core24
-version: '3.4.0'
+version: '3.4.1'
 summary: tldr python client
 description: Official Python command-line client for tldr pages.
 


### PR DESCRIPTION
## Changes

- Make all jobs run one after another, to prevent too many HTTP request errors causing build failures.
- Make snap build job run on tags too (currently it runs only on commits to main)
- Bump snapcraft version to 3.4.1.