### PR TITLE
gitignore: Ignore common IDE folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
-# VsCode IDE
+# IDEs
 .vscode/
-
-# JetBrains IDEs
 .idea/
 
 # Byte-compiled / optimized / DLL files


### PR DESCRIPTION
Ignore .vscode and .idea to keep the repository clean and
avoid cluttering it with IDE-specific configuration files.