### PR TITLE
tldr: fix tab completion

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -401,7 +401,6 @@ def get_commands(platforms: Optional[List[str]] = None,
                 path = get_cache_dir() / pages_dir / platform
                 if not path.exists():
                     continue
-                languagestring = ""
                 commands += [f"{file.stem}"
                              for file in path.iterdir()
                              if file.suffix == '.md']

--- a/tldr.py
+++ b/tldr.py
@@ -401,7 +401,10 @@ def get_commands(platforms: Optional[List[str]] = None,
                 path = get_cache_dir() / pages_dir / platform
                 if not path.exists():
                     continue
-                commands += [f"{file.stem} ({language})"
+                languagestring = ""
+                if language != 'en':
+                    languagestring = f" ({language})"
+                commands += [f"{file.stem}{languagestring}"
                              for file in path.iterdir()
                              if file.suffix == '.md']
     return commands
@@ -654,10 +657,10 @@ def create_parser() -> ArgumentParser:
 
     shtab.add_argument_to(parser, preamble={
         'bash': r'''shtab_tldr_cmd_list(){{
-          compgen -W "$("{py}" -m tldr --list | sed 's/[^[:alnum:]_]/ /g')" -- "$1"
+          compgen -W "$("{py}" -m tldr --list)" -- "$1"
         }}'''.format(py=sys.executable),
         'zsh': r'''shtab_tldr_cmd_list(){{
-          _describe 'command' "($("{py}" -m tldr --list | sed 's/[^[:alnum:]_]/ /g'))"
+          _describe 'command' "($("{py}" -m tldr --list))"
         }}'''.format(py=sys.executable)
     })
 

--- a/tldr.py
+++ b/tldr.py
@@ -402,9 +402,7 @@ def get_commands(platforms: Optional[List[str]] = None,
                 if not path.exists():
                     continue
                 languagestring = ""
-                if language != 'en':
-                    languagestring = f" ({language})"
-                commands += [f"{file.stem}{languagestring}"
+                commands += [f"{file.stem}"
                              for file in path.iterdir()
                              if file.suffix == '.md']
     return commands


### PR DESCRIPTION
I finally got fed up with the tab completion not working correctly. This change makes `--list` not show the language marker which cascades into the tab completion. Also this removes the `sed` command from the completion that was replacing non-alphanumeric characters with space which led to things like `systemctl\ enable`

Fixes #288
Fixes #211