### PR TITLE
requirements: install colorama on all platforms

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 termcolor
-colorama; sys_platform=='win32'
+colorama
 shtab>=1.3.10


### PR DESCRIPTION
I assume this change installs colorama on all platforms to get rid of a CI error.