### PR TITLE
chore: update 'requires-python' version specifier to avoid ambiguity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Official Python command line client for tldr pages."
 readme = "README.md"
 license = "MIT"
-requires-python = "~=3.9"
+requires-python = ">=3.9"
 authors = [
     { name = "Felix Yan and tldr-pages contributors" },
 ]


### PR DESCRIPTION
Hi,

I was about to start playing around with #267 and #278 locally and got the following warning:

<img width="1280" height="659" alt="screenshot_from_2025_10_08_16_42_49" src="https://github.com/user-attachments/assets/fb67dd8a-9cbc-4c16-bd91-836f55922983" />

Assuming the `~=3.9` was intentional to avoid a 4.x major version change, it might not be necessary as Python 4.x doesn't seem to be likely at all: https://www.geeksforgeeks.org/python/latest-update-on-python-4/

> "We’re not thrilled about the idea of Python 4 and nobody in the core dev team is—so probably there never will be a version 4.0 and we’ll just keep numbering until 3.99," van Rossum stated. He emphasized that the transition from Python 2 to Python 3 was challenging and that the team learned valuable lessons from this experience. The team’s focus is on incremental improvements within the Python 3.x series rather than introducing a major version overhaul.

This PR swaps the `~=` for a simple `>=`, which dismisses the best practices warning from `uv`:

<img width="1280" height="602" alt="screenshot_from_2025_10_09_07_17_56" src="https://github.com/user-attachments/assets/1835b2ca-d474-4360-80bb-177f12fd97d4" />

Apologies for not logging an issue first, I wasn't sure if this would be considered valid or desired.

As a sidenote: Python 3.9 is also approaching EOL this month (October 2025). I'd be happy to make another PR to drop 3.9 support and bump the minimum version to 3.10 if you like?

Cheers,
Kyle

