### PR TITLE
fix: only raise URLError or HTTPError when there are no results at all

### DIFF
--- a/tldr.py
+++ b/tldr.py
@@ -281,6 +281,7 @@ def get_page_for_every_platform(
             return result
     # Know here that we don't have the info in cache
     result = list()
+    error = None
     for platform in platforms:
         for language in languages:
             if platform is None:
@@ -300,13 +301,22 @@ def get_page_for_every_platform(
                 break
             except HTTPError as err:
                 if err.code != 404:
-                    raise
-            except URLError:
+                    # Store error for later, only raise if we find no results at all
+                    error = err
+            except URLError as err:
                 if not PAGES_SOURCE_LOCATION.startswith('file://'):
-                    raise
+                    # Store error for later, only raise if we find no results at all
+                    error = err
+
     if result:  # Return if smth was found
         return result
 
+    # Reraise the error if we couldn't get the pages for any platform
+    if error is not None:
+        # Note that only the most recent error will be stored and raised
+        raise error
+
+    # Otherwise, we got no results nor errors, implies the documentation doesn't exist
     return False
 
 


### PR DESCRIPTION
As discussed in https://github.com/tldr-pages/tldr-python-client/issues/267#issuecomment-3383676960

One of the scenarios in which a `URLError` is received is when the request for a page fails on a subset of the platforms, but some platforms succeed. In this case, we should display the result that was retrieved successfully instead of throwing an error.

Sample output:

<img width="1279" height="841" alt="screenshot_from_2025_10_09_10_10_26" src="https://github.com/user-attachments/assets/f5e37c3c-0def-40ea-8b85-d9f8c133da3a" />

This shows the subset of requests that failed and the one that succeeded, then displays the result. The extra logging to demonstrate the process locally I removed before committing.

This will resolve the error I received earlier:

```
Error fetching from tldr: <urlopen error _ssl.c:990: The handshake operation timed out>
```